### PR TITLE
Transform is enabled, improvement, and implemented for a struct

### DIFF
--- a/src/cgmath/lib.rs
+++ b/src/cgmath/lib.rs
@@ -35,6 +35,7 @@ pub mod plane;
 pub mod point;
 pub mod ray;
 pub mod rotation;
+pub mod transform;
 
 pub mod projection;
 

--- a/src/cgmath/transform.rs
+++ b/src/cgmath/transform.rs
@@ -13,10 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub trait Transform<S> {
-    fn transform_vec(&self, point: Point3<S>) -> Point3<S>;
-    fn transform_point(&self, point: Point3<S>) -> Point3<S>;
-    fn transform_ray(&self, ray: Ray3<S>) -> Ray3<S>;
+use matrix::Mat4;
+use point::{Point,Point3};
+use ray::Ray3;
+use rotation::Rotation3;
+use vector::{Vector,Vec3};
+
+
+pub trait Transform3<S> {
+    fn transform_vec3(&self, vec: &Vec3<S>) -> Vec3<S>;
+    fn transform_point3(&self, point: &Point3<S>) -> Point3<S>;
+    
+    #[inline]
+    fn transform_ray3(&self, ray: &Ray3<S>) -> Ray3<S>    {
+        Ray3::new( self.transform_point3(&ray.origin), self.transform_vec3(&ray.direction) )
+    }
 }
 
 /// A homogeneous transformation matrix.
@@ -26,15 +37,27 @@ pub struct AffineMatrix3<S> {
 
 /// A transformation in three dimensions consisting of a rotation,
 /// displacement vector and scale amount.
-pub struct Transform3<S, R> {
+pub struct Transform3D<S, R> {
     rot: R,
     disp: Vec3<S>,
     scale: S,
 }
 
-impl<S: Float, R: Rotation3<S>> Transform3<S, R> {
+impl<S: Float, R: Rotation3<S>> Transform3D<S, R> {
     #[inline]
-    pub fn new(rot: R, disp: Vec3<S>, scale: S) -> Transform3<S, R> {
-        Transform3 { rot: rot, disp: disp, scale: S }
+    pub fn new(rot: R, disp: Vec3<S>, scale: S) -> Transform3D<S, R> {
+        Transform3D { rot: rot, disp: disp, scale: scale }
+    }
+}
+
+impl <S: Float, R: Rotation3<S>> Transform3<S> for Transform3D<S,R>   {
+    #[inline]
+    fn transform_vec3(&self, vec: &Vec3<S>) -> Vec3<S>   {
+        self.rot.rotate_vec3( &vec.mul_s( self.scale.clone() ))
+    }
+
+    #[inline]
+    fn transform_point3(&self, point: &Point3<S>) -> Point3<S>   {
+        self.rot.rotate_point3( &point.mul_s( self.scale.clone() )).add_v( &self.disp )
     }
 }


### PR DESCRIPTION
I renamed the trait to Transform3 in order to match naming of Ray,Point,Rotation,etc. Same goes for its methods. Optimally, we may want to pass vector and point traits as generic arguments, but that can probably wait until Rust gets integer generic parameters (for Dimension).
