### PR TITLE
derive IterBytes for all structs

### DIFF
--- a/src/cgmath/angle.rs
+++ b/src/cgmath/angle.rs
@@ -23,8 +23,8 @@ use std::num::{One, one, Zero, zero, cast};
 
 use approx::ApproxEq;
 
-#[deriving(Clone, Eq, Ord)] pub struct Rad<S> { s: S }
-#[deriving(Clone, Eq, Ord)] pub struct Deg<S> { s: S }
+#[deriving(Clone, Eq, Ord, IterBytes)] pub struct Rad<S> { s: S }
+#[deriving(Clone, Eq, Ord, IterBytes)] pub struct Deg<S> { s: S }
 
 #[inline] pub fn rad<S: Float>(s: S) -> Rad<S> { Rad { s: s } }
 #[inline] pub fn deg<S: Float>(s: S) -> Deg<S> { Deg { s: s } }

--- a/src/cgmath/point.rs
+++ b/src/cgmath/point.rs
@@ -24,11 +24,11 @@ use array::*;
 use vector::*;
 
 /// A point in 2-dimensional space.
-#[deriving(Eq, Clone)]
+#[deriving(Eq, Clone, IterBytes)]
 pub struct Point2<S> { x: S, y: S }
 
 /// A point in 3-dimensional space.
-#[deriving(Eq, Clone)]
+#[deriving(Eq, Clone, IterBytes)]
 pub struct Point3<S> { x: S, y: S, z: S }
 
 

--- a/src/cgmath/vector.rs
+++ b/src/cgmath/vector.rs
@@ -79,7 +79,7 @@ pub trait Vector
 // Utility macro for generating associated functions for the vectors
 macro_rules! vec(
     ($Self:ident <$S:ident> { $($field:ident),+ }, $n:expr) => (
-        #[deriving(Eq, Clone)]
+        #[deriving(Eq, Clone, IterBytes)]
         pub struct $Self<S> { $($field: S),+ }
 
         impl<$S: Primitive> $Self<$S> {


### PR DESCRIPTION
It's useful to be able to have types like Vec3<i32> as hashtable keys. I
included all of the other structs as well for consistency.
