### PR TITLE
Fix quat::Quat::from_angle_{x|y|z}

### DIFF
--- a/src/cgmath/quaternion.rs
+++ b/src/cgmath/quaternion.rs
@@ -47,21 +47,21 @@ Quat<S> {
         Quat { s: s, v: v }
     }
 
-    /// Create a matrix from a rotation around the `x` axis (pitch).
+    /// Create a quaternion from a rotation around the `x` axis (pitch).
     #[inline]
     pub fn from_angle_x(theta: Rad<S>) -> Quat<S> {
         let (s, c) = sin_cos(theta.mul_s(cast(0.5).unwrap()));
         Quat::new(c, s, zero(), zero())
     }
 
-    /// Create a matrix from a rotation around the `y` axis (yaw).
+    /// Create a quaternion from a rotation around the `y` axis (yaw).
     #[inline]
     pub fn from_angle_y(theta: Rad<S>) -> Quat<S> {
         let (s, c) = sin_cos(theta.mul_s(cast(0.5).unwrap()));
         Quat::new(c, zero(), s, zero())
     }
 
-    /// Create a matrix from a rotation around the `z` axis (roll).
+    /// Create a quaternion from a rotation around the `z` axis (roll).
     #[inline]
     pub fn from_angle_z(theta: Rad<S>) -> Quat<S> {
         let (s, c) = sin_cos(theta.mul_s(cast(0.5).unwrap()));


### PR DESCRIPTION
These functions were broken due to mistakenly using the full angle theta in one place instead of theta / 2. This resulted in non-unit quaternions that definitely did not rotate things correctly.
