### PR TITLE
Implement float-like operations for vectors.

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -93,3 +93,39 @@ pub trait BaseFloat : BaseNum + FloatMath + ApproxEq<Self> + fmt::Float {}
 
 impl BaseFloat for f32 {}
 impl BaseFloat for f64 {}
+
+/// Represents an object for which float-like operations are sensible. This
+/// trait provides similar methods to the built-in Float and FloatMath.
+pub trait FloatOperations<T: BaseFloat> {
+    /// Find the largest integer which is smaller than this object.
+    fn floor(&self) -> Self;
+    /// Find the  smallest integer which is larger than this object.
+    fn ceil(&self) -> Self;
+    /// Remove the integer part of the object.
+    fn fract(&self) -> Self;
+    /// Remove the non-integer part of the object.
+    fn trunc(&self) -> Self;
+    /// Round the object to the nearest integer.
+    fn round(&self) -> Self;
+    /// Take the natural logarithm of the object.
+    fn ln(&self) -> Self;
+    /// Calculate the exponent of the object.
+    fn exp(&self) -> Self;
+    /// Calculate the square root of the object.
+    fn sqrt(&self) -> Self;
+    /// Calculate the inverse square root of the object.
+    fn rsqrt(&self) -> Self;
+    /// Calculate the multiplicative inverse of the object.
+    fn recip(&self) -> Self;
+    /// Raise the object to the power `n`.
+    fn powi(&self, n: i32) -> Self;
+    /// Raise the object to the power `n`. This method will usually be slower
+    /// than the integer version.
+    fn powf(&self, n: T) -> Self;
+    /// Take the logarithm of base `base` of the object.
+    fn log(&self, base: T) -> Self;
+    /// Find the larger of the two objects.
+    fn max(&self, other: T) -> Self;
+    /// Find the smaller of the two objects.
+    fn min(&self, other: T) -> Self;
+}

--- a/src/test/vector.rs
+++ b/src/test/vector.rs
@@ -157,3 +157,48 @@ fn test_normalize() {
     assert!(Vector3::new(2.0f64, 3.0f64, 6.0f64).normalize().approx_eq( &Vector3::new(2.0/7.0, 3.0/7.0, 6.0/7.0) ));
     assert!(Vector4::new(1.0f64, 2.0f64, 4.0f64, 10.0f64).normalize().approx_eq( &Vector4::new(1.0/11.0, 2.0/11.0, 4.0/11.0, 10.0/11.0) ));
 }
+
+#[cfg(test)]
+mod test_float_operations {
+    use cgmath::vector::*;
+    use cgmath::num::FloatOperations;
+    
+    #[test]
+    fn test_floor_ceil_fract_trunc_round() {
+        let a = Vector3::new(3.14f64, 5.2f64, 6.73f64);
+        let b = -a;
+        assert_eq!(a.trunc() + a.fract(), a);
+        assert_eq!(a.floor() + a.fract(), a);
+        assert_eq!(b.ceil() + b.fract(), b);
+        assert_eq!(a.ceil() - a.floor(), Vector3::from_value(1.0f64));
+        assert_eq!(b.round(), Vector3::new(-3.0f64, -5.0f64, -7.0f64));
+    }
+
+    #[test]
+    fn test_ln_exp() {
+        let a = Vector3::new(3.14f64, 5.2f64, 6.73f64);
+        assert_eq!(a.exp().ln(), a);
+    }
+
+    #[test]
+    fn test_sqrt_rsqrt_recip() {
+        let a = Vector3::new(3.14f64, 5.2f64, 6.73f64);
+        assert_eq!(a.sqrt() * a.rsqrt(), Vector3::from_value(1.0f64));
+        assert_eq!(a.recip() * a, Vector3::from_value(1.0f64));
+    }
+
+    #[test]
+    fn test_pow_log() {
+        let a = Vector3::new(3.0f64, 5.0f64, 6.0f64);
+        let b = -a;
+        assert_eq!(a.powi(2), Vector3::new(9.0f64, 25.0f64, 36.0f64));
+        assert_eq!(a.powi(2), b.powf(2.0f64));
+        assert_eq!(Vector3::from_value(1.0f64).log(10.0f64), Vector3::from_value(0.0f64));
+    }
+
+    #[test]
+    fn test_min_max() {
+        assert_eq!(Vector3::new(3.0f64, 5.0f64, 6.0f64).min(5.0f64), Vector3::new(3.0f64, 5.0f64, 5.0f64));
+        assert_eq!(Vector3::new(3.0f64, 5.0f64, 6.0f64).max(5.0f64), Vector3::new(5.0f64, 5.0f64, 6.0f64));
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -20,7 +20,7 @@ use std::num::{Zero, zero, One, one};
 use angle::{Rad, atan2, acos};
 use approx::ApproxEq;
 use array::Array1;
-use num::{BaseNum, BaseFloat};
+use num::{BaseNum, BaseFloat, FloatOperations};
 
 /// A trait that specifies a range of numeric operations for vectors. Not all
 /// of these make sense from a linear algebra point of view, but are included
@@ -422,3 +422,30 @@ impl<S: BaseNum> fmt::Show for Vector4<S> {
         write!(f, "[{}, {}, {}, {}]", self.x, self.y, self.z, self.w)
     }
 }
+
+// Utility macro for implementing FloatOperations for vectors of floats
+macro_rules! vector_floatoperations (
+    ($Self:ident <$S:ident>, $($field:ident),+ ) => (
+            impl<$S : BaseFloat> FloatOperations<$S> for $Self<$S> {
+                #[inline] fn floor(&self) -> $Self<$S> { $Self::new($(self.$field.floor()),+) }
+                #[inline] fn ceil(&self) -> $Self<$S> { $Self::new($(self.$field.ceil()),+) }
+                #[inline] fn fract(&self) -> $Self<$S> { $Self::new($(self.$field.fract()),+) }
+                #[inline] fn trunc(&self) -> $Self<$S> { $Self::new($(self.$field.trunc()),+) }
+                #[inline] fn round(&self) -> $Self<$S> { $Self::new($(self.$field.round()),+) }
+                #[inline] fn ln(&self) -> $Self<$S> { $Self::new($(self.$field.ln()),+) }
+                #[inline] fn exp(&self) -> $Self<$S> { $Self::new($(self.$field.exp()),+) }
+                #[inline] fn sqrt(&self) -> $Self<$S> { $Self::new($(self.$field.sqrt()),+) }
+                #[inline] fn rsqrt(&self) -> $Self<$S> { $Self::new($(self.$field.rsqrt()),+) }
+                #[inline] fn recip(&self) -> $Self<$S> { $Self::new($(self.$field.recip()),+) }
+                #[inline] fn powi(&self, n: i32) -> $Self<$S> { $Self::new($(self.$field.powi(n)),+) }
+                #[inline] fn powf(&self, n: $S) -> $Self<$S> { $Self::new($(self.$field.powf(n)),+) }
+                #[inline] fn log(&self, base: $S) -> $Self<$S> { $Self::new($(self.$field.log(base)),+) }
+                #[inline] fn min(&self, other: $S) -> $Self<$S> { $Self::new($(self.$field.min(other)),+) }
+                #[inline] fn max(&self, other: $S) -> $Self<$S> { $Self::new($(self.$field.max(other)),+) }
+        }
+    )
+)
+
+vector_floatoperations!(Vector2<S>, x, y)
+vector_floatoperations!(Vector3<S>, x, y, z)
+vector_floatoperations!(Vector4<S>, x, y, z, w)


### PR DESCRIPTION
I was wondering if there was interest in adding this feature. In GLSL code, you can call `floor`, `max`, and so on with vector arguments, and the function is automatically vectorized over the components. This commit allows for similar functionality, i.e.

``` rust
assert_eq!(Vector3::new(4.56, 5.78, -0.91).floor(), Vector3::new(4.0, 5.0, -1.0));
```

The commit adds a new trait to the `num` module similar to the built-in FloatMath and Float, and then implements it for vectors in the `vector` module. I've also included complete test coverage for all of the functions, and full documentation for the trait. It compiles and runs on my machine without issue.

Caveats:
- There are no trigonometric functions (yet), because I think that an implementation ought to respect the `Angle` type in some way.
- I didn't add top-level functions (i.e. `pub fn floor<S: FloatOperations>(s: S) -> S { t.floor() }`), because I'm not sure what module they would belong in; and
- The implementation is only for vectors right now. If there's interest I don't see why it can't be done for matrices as well.

I'm very new to Rust, so any feedback on the code itself would be welcome.
