### PR TITLE
 Change package name from "cgmath-rs" to "cgmath"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "cgmath-rs"
+name = "cgmath"
 version = "0.0.1"
 authors = ["Brendan Zabarauskas <bjzaba@yahoo.com.au>",
         "Brian Heylin",


### PR DESCRIPTION
When the Cargo package manager gets the online package list component, the package name 
will be used as the identifier for the whole project. Keeping "-rs" -- while useful for the github 
repository -- will be redundant in Cargo because all of the projects will obviously be rust projects.

This naming convention was adopted by one of your other repository gl-rx (https://github.com/bjz/gl-rs/pull/88)
