### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pull request with a fix.
 
 ## Documentation
 
-[View](rust-ci.org/bjz/cgmath-rs/doc/cgmath/)
+[View](http://rust-ci.org/bjz/cgmath-rs/doc/cgmath/index.html)
 
 ## Limitations
 


### PR DESCRIPTION
The old link was appended to the github link, leading to a 404
