### PR TITLE
Actually implement division, remainder, and index operators for vectors.

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -215,6 +215,18 @@ macro_rules! vec(
             #[inline] fn one() -> $Self<S> { $Self::from_value(one()) }
         }
 
+        impl<S: BaseNum> Index<uint, S> for $Self<S> {
+            #[inline]
+            fn index<'a>(&'a self, index: &uint) -> &'a S {
+                let slice: &[S, ..$n] = unsafe { mem::transmute(self) };
+                &slice[*index]
+            }
+        }
+
+        impl<S: BaseNum> IndexMut<uint, S> for $Self<S> {
+            #[inline] fn index_mut<'a>(&'a mut self, index: &uint) -> &'a mut S { self.mut_i(*index) }
+        }
+
         impl<S: BaseFloat> ApproxEq<S> for $Self<S> {
             #[inline]
             fn approx_eq_eps(&self, other: &$Self<S>, epsilon: &S) -> bool {


### PR DESCRIPTION
The code for doing this was available through methods, but it's nice to have access to Rust's operators as well. These operators join add, subtract, multiply, and negate, which are already implemented.

The `transmute` syntax is identical to the content of the `i()` method implementation, but since we need to return a borrowed reference with a lifetime we can't just use `&self.i(*index)` without changing that method to use a lifetime in turn.
