### PR TITLE
Fix `Matrix2::from_angle()` invocation and add a test for the feature.

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -90,8 +90,8 @@ impl<S: BaseFloat> Matrix2<S> {
         let cos_theta = cos(theta.clone());
         let sin_theta = sin(theta.clone());
 
-        Matrix2::new(cos_theta.clone(), -sin_theta.clone(),
-                     sin_theta.clone(),  cos_theta.clone())
+        Matrix2::new(cos_theta.clone(),  sin_theta.clone(),
+                     -sin_theta.clone(), cos_theta.clone())
     }
 }
 

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -149,7 +149,7 @@ pub trait Rotation3<S: BaseNum>: Rotation<S, Vector3<S>, Point3<S>>
 ///
 /// // Since sin(π/2) may not be exactly zero due to rounding errors, we can
 /// // use cgmath's approx_eq() feature to show that it is close enough.
-/// assert!(unit_y.approx_eq(&-Vector2::unit_y()));
+/// assert!(unit_y.approx_eq(&Vector2::unit_y()));
 ///
 /// // This is exactly equivalent to using the raw matrix itself:
 /// let unit_y2 = rot.to_matrix2().mul_v(&unit_x);

--- a/src/test/matrix.rs
+++ b/src/test/matrix.rs
@@ -15,6 +15,7 @@
 
 use cgmath::matrix::*;
 use cgmath::vector::*;
+use cgmath::angle::rad;
 use cgmath::approx::ApproxEq;
 
 pub mod matrix2 {
@@ -394,4 +395,19 @@ fn test_predicates() {
     assert!(matrix4::D.is_invertible());
 
     assert!(Matrix4::from_value(6.0f64).is_diagonal());
+}
+
+#[test]
+fn test_from_angle() {
+    // Rotate the vector (1, 0) by π/2 radians to the vector (0, 1)
+    let rot1 = Matrix2::from_angle(rad(0.5f64 * Float::pi()));
+    assert!(rot1.mul_v(&Vector2::unit_x()).approx_eq(&Vector2::unit_y()));
+
+    // Rotate the vector (-1, 0) by -π/2 radians to the vector (0, 1)
+    let rot2 = -rot1;
+    assert!(rot2.mul_v(&-Vector2::unit_x()).approx_eq(&Vector2::unit_y()));
+
+    // Rotate the vector (1, 1) by π radians to the vector (-1, -1)
+    let rot3: Matrix2<f64> = Matrix2::from_angle(rad(Float::pi()));
+    assert!(rot3.mul_v(&Vector2::new(1.0, 1.0)).approx_eq(&Vector2::new(-1.0, -1.0)));
 }


### PR DESCRIPTION
I originally noticed this oddity when writing the documentation examples for Basis2, but was not sure why it was occurring. The current `Matrix2::from_angle()` will rotate vectors clockwise, as opposed to counterclockwise.

If it is an error, it's probably caused by someone forgetting that the `new()` method takes entries column-wise, not row-wise. But this might be intentional; there is a mention in [Wikipedia's definition](http://en.wikipedia.org/wiki/Rotation_matrix) of a rotation matrix in computer graphics preferring clockwise rotation.

I have also added a test function to the matrix test suite and fixed the example for Basis2 to account for this change.
