### PR TITLE
Assertion macros for approximate equality

### DIFF
--- a/src/approx.rs
+++ b/src/approx.rs
@@ -42,3 +42,29 @@ macro_rules! approx_float(
 
 approx_float!(f32)
 approx_float!(f64)
+
+#[macro_export]
+macro_rules! assert_approx_eq_eps(
+    ($given: expr, $expected: expr, $eps: expr) => ({
+        let eps = &($eps);
+        let (given_val, expected_val) = (&($given), &($expected));
+        if !given_val.approx_eq_eps(expected_val, eps) {
+            fail!("assertion failed: `left ≈ right` (left: `{}`, right: `{}`, tolerance: `{}`)",
+                *given_val, *expected_val, *eps
+            )
+        }
+    })
+)
+
+#[macro_export]
+macro_rules! assert_approx_eq(
+    ($given: expr, $expected: expr) => ({
+        let (given_val, expected_val) = (&($given), &($expected));
+        if !given_val.approx_eq(expected_val) {
+            fail!("assertion failed: `left ≈ right` (left: `{}`, right: `{}`, tolerance: `{}`)",
+                *given_val, *expected_val,
+                ApproxEq::approx_epsilon(Some(*given_val))
+            )
+        }
+    })
+)

--- a/tests/approx.rs
+++ b/tests/approx.rs
@@ -1,0 +1,44 @@
+// Copyright 2014 The CGMath Developers. For a full listing of the authors,
+// refer to the AUTHORS file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(globs)]
+#![feature(phase)]
+
+#[phase(plugin, link)]
+extern crate cgmath;
+
+use cgmath::*;
+
+#[test]
+fn macro_assert_approx_eq_eps() {
+    assert_approx_eq_eps!(1.0f64, 1.001, 0.01);
+}
+
+#[test]
+#[should_fail]
+fn macro_assert_approx_eq_eps_fail() {
+    assert_approx_eq_eps!(1.0f32, 1.02, 0.01);
+}
+
+#[test]
+fn macro_assert_approx_eq() {
+    assert_approx_eq!(7.0f32 / 5.0, 1.4);
+}
+
+#[test]
+#[should_fail]
+fn macro_assert_approx_eq_fail() {
+    assert_approx_eq!(1.0f64 / 3.0, 0.333);
+}


### PR DESCRIPTION
For sake of readability and consistency with the standard library macros
assert! and assert_eq!, the macros assert_approx_eq! and assert_approx_eq_eps!
have been implemented based on the ApproxEq trait.

Upon failure these macros yield readable error messages including the input
values and the tolerance (epsilon) used to determine their approximate
equality.

Resolves #131.
