### PR TITLE
Fix for orthographic projection and removed constraints on input

### DIFF
--- a/src/projection.rs
+++ b/src/projection.rs
@@ -215,10 +215,6 @@ impl<S: BaseFloat> Projection<S> for Ortho<S> {
 
 impl<S: BaseFloat> ToMatrix4<S> for Ortho<S> {
     fn to_matrix4(&self) -> Matrix4<S> {
-        assert!(self.left   < self.right, "`left` cannot be greater than `right`, found: left: {} right: {}", self.left, self.right);
-        assert!(self.bottom < self.top,   "`bottom` cannot be greater than `top`, found: bottom: {} top: {}", self.bottom, self.top);
-        assert!(self.near   < self.far,   "`near` cannot be greater than `far`, found: near: {} far: {}", self.near, self.far);
-
         let two: S = cast(2i).unwrap();
 
         let c0r0 = two / (self.right - self.left);


### PR DESCRIPTION
Removing the asserts allows inverting axis direction. For example for 2D grahics it is common to have  the Y axis pointing downwards.
