### PR TITLE
Add deriving Copy; Fix warnings

### DIFF
--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -84,7 +84,7 @@ pub trait Aabb<S: BaseNum, V: Vector<S>, P: Point<S, V>> {
 }
 
 /// A two-dimensional AABB, aka a rectangle.
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Aabb2<S> {
     pub min: Point2<S>,
     pub max: Point2<S>,
@@ -129,7 +129,7 @@ impl<S: BaseNum> fmt::Show for Aabb2<S> {
 }
 
 /// A three-dimensional AABB, aka a rectangular prism.
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Aabb3<S> {
     pub min: Point3<S>,
     pub max: Point3<S>,

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -23,10 +23,10 @@ use approx::ApproxEq;
 use num::{BaseFloat, One, one, Zero, zero};
 
 /// An angle, in radians
-#[deriving(Clone, PartialEq, PartialOrd, Hash, Encodable, Decodable, Rand)]
+#[deriving(Copy, Clone, PartialEq, PartialOrd, Hash, Encodable, Decodable, Rand)]
 pub struct Rad<S> { pub s: S }
 /// An angle, in degrees
-#[deriving(Clone, PartialEq, PartialOrd, Hash, Encodable, Decodable, Rand)]
+#[deriving(Copy, Clone, PartialEq, PartialOrd, Hash, Encodable, Decodable, Rand)]
 pub struct Deg<S> { pub s: S }
 
 /// Create a new angle, in radians
@@ -77,7 +77,7 @@ pub trait Angle
     S: BaseFloat
 >
 :   Clone + Zero
-+   PartialEq + Equiv<Self> + PartialOrd
++   PartialEq + PartialOrd
 +   ApproxEq<S>
 +   Neg<Self>
 +   ToRad<S>
@@ -153,6 +153,8 @@ pub trait Angle
     #[inline] fn turn_div_3() -> Self { let full_turn: Self = Angle::full_turn(); full_turn.div_s(cast(3i).unwrap()) }
     #[inline] fn turn_div_4() -> Self { let full_turn: Self = Angle::full_turn(); full_turn.div_s(cast(4i).unwrap()) }
     #[inline] fn turn_div_6() -> Self { let full_turn: Self = Angle::full_turn(); full_turn.div_s(cast(6i).unwrap()) }
+    
+    #[inline] fn equiv(&self, other: &Self) -> bool { self.normalize() == other.normalize() }
 }
 
 #[inline] pub fn bisect<S: BaseFloat, A: Angle<S>>(a: A, b: A) -> A { a.bisect(b) }
@@ -195,20 +197,6 @@ impl<S: BaseFloat> Mul<Deg<S>, Deg<S>> for Deg<S> { #[inline] fn mul(&self, othe
 
 impl<S: BaseFloat> One for Rad<S> { #[inline] fn one() -> Rad<S> { rad(one()) } }
 impl<S: BaseFloat> One for Deg<S> { #[inline] fn one() -> Deg<S> { deg(one()) } }
-
-impl<S: BaseFloat>
-Equiv<Rad<S>> for Rad<S> {
-    fn equiv(&self, other: &Rad<S>) -> bool {
-        self.normalize() == other.normalize()
-    }
-}
-
-impl<S: BaseFloat>
-Equiv<Deg<S>> for Deg<S> {
-    fn equiv(&self, other: &Deg<S>) -> bool {
-        self.normalize() == other.normalize()
-    }
-}
 
 impl<S: BaseFloat>
 Angle<S> for Rad<S> {

--- a/src/cgmath.rs
+++ b/src/cgmath.rs
@@ -15,8 +15,6 @@
 
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![comment = "A mathematics library for computer graphics."]
-#![license = "ASL2"]
 
 #![feature(globs)]
 #![feature(macro_rules)]

--- a/src/cylinder.rs
+++ b/src/cylinder.rs
@@ -18,7 +18,7 @@
 use point::Point3;
 use vector::Vector3;
 
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Cylinder<S> {
     pub center: Point3<S>,
     pub axis: Vector3<S>,

--- a/src/frustum.rs
+++ b/src/frustum.rs
@@ -22,7 +22,7 @@ use plane::Plane;
 use point::Point3;
 use vector::{Vector, EuclideanVector};
 
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Frustum<S> {
     pub left:   Plane<S>,
     pub right:  Plane<S>,
@@ -59,7 +59,7 @@ Frustum<S> {
     }
 }
 
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct FrustumPoints<S> {
     pub near_top_left:     Point3<S>,
     pub near_top_right:    Point3<S>,

--- a/src/line.rs
+++ b/src/line.rs
@@ -22,7 +22,7 @@ use ray::{Ray2};
 use intersect::Intersect;
 
 /// A generic directed line segment from `origin` to `dest`.
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Line<P> {
     pub origin: P,
     pub dest: P,

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -29,15 +29,15 @@ use vector::{Vector, EuclideanVector};
 use vector::{Vector2, Vector3, Vector4};
 
 /// A 2 x 2, column major matrix
-#[deriving(Clone, PartialEq, Encodable, Decodable, Rand)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable, Rand)]
 pub struct Matrix2<S> { pub x: Vector2<S>, pub y: Vector2<S> }
 
 /// A 3 x 3, column major matrix
-#[deriving(Clone, PartialEq, Encodable, Decodable, Rand)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable, Rand)]
 pub struct Matrix3<S> { pub x: Vector3<S>, pub y: Vector3<S>, pub z: Vector3<S> }
 
 /// A 4 x 4, column major matrix
-#[deriving(Clone, PartialEq, Encodable, Decodable, Rand)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable, Rand)]
 pub struct Matrix4<S> { pub x: Vector4<S>, pub y: Vector4<S>, pub z: Vector4<S>, pub w: Vector4<S> }
 
 

--- a/src/obb.rs
+++ b/src/obb.rs
@@ -18,14 +18,14 @@
 use point::{Point2, Point3};
 use vector::{Vector2, Vector3};
 
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Obb2<S> {
     pub center: Point2<S>,
     pub axis: Vector2<S>,
     pub extents: Vector2<S>,
 }
 
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Obb3<S> {
     pub center: Point3<S>,
     pub axis: Vector3<S>,

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -39,7 +39,7 @@ use vector::{Vector, EuclideanVector};
 /// The `A*x + B*y + C*z - D = 0` form is preferred over the other common
 /// alternative, `A*x + B*y + C*z + D = 0`, because it tends to avoid
 /// superfluous negations (see _Real Time Collision Detection_, p. 55).
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Plane<S> {
     pub n: Vector3<S>,
     pub d: S,

--- a/src/point.rs
+++ b/src/point.rs
@@ -26,11 +26,11 @@ use num::{BaseNum, BaseFloat, one, zero};
 use vector::*;
 
 /// A point in 2-dimensional space.
-#[deriving(PartialEq, Clone, Hash, Encodable, Decodable)]
+#[deriving(PartialEq, Copy, Clone, Hash, Encodable, Decodable)]
 pub struct Point2<S> { pub x: S, pub y: S }
 
 /// A point in 3-dimensional space.
-#[deriving(PartialEq, Clone, Hash, Encodable, Decodable)]
+#[deriving(PartialEq, Copy, Clone, Hash, Encodable, Decodable)]
 pub struct Point3<S> { pub x: S, pub y: S, pub z: S }
 
 

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -69,7 +69,7 @@ pub trait Projection<S>: ToMatrix4<S> {
 }
 
 /// A perspective projection based on a vertical field-of-view angle.
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct PerspectiveFov<S, A> {
     pub fovy:   A,
     pub aspect: S,
@@ -143,7 +143,7 @@ impl<S: BaseFloat, A: Angle<S>> ToMatrix4<S> for PerspectiveFov<S, A> {
 }
 
 /// A perspective projection with arbitrary left/right/bottom/top distances
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Perspective<S> {
     pub left:   S,  right:  S,
     pub bottom: S,  top:    S,
@@ -193,7 +193,7 @@ impl<S: BaseFloat + 'static> ToMatrix4<S> for Perspective<S> {
 }
 
 /// An orthographic projection with arbitrary left/right/bottom/top distances
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Ortho<S> {
     pub left:   S,  right:  S,
     pub bottom: S,  top:    S,

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -29,7 +29,7 @@ use vector::{Vector3, Vector, EuclideanVector};
 
 /// A [quaternion](https://en.wikipedia.org/wiki/Quaternion) in scalar/vector
 /// form.
-#[deriving(Clone, PartialEq, Encodable, Decodable, Rand)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable, Rand)]
 pub struct Quaternion<S> { pub s: S, pub v: Vector3<S> }
 
 /// Represents types which can be expressed as a quaternion.

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -19,7 +19,7 @@ use vector::{Vector, Vector2, Vector3};
 
 /// A generic ray starting at `origin` and extending infinitely in
 /// `direction`.
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Ray<P,V> {
     pub origin: P,
     pub direction: V,

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -161,7 +161,7 @@ pub trait Rotation3<S: BaseNum>: Rotation<S, Vector3<S>, Point3<S>>
 /// let unit_y3 = rot_half.concat(&rot_half).rotate_vector(&unit_x);
 /// assert!(unit_y3.approx_eq(&unit_y2));
 /// ```
-#[deriving(PartialEq, Clone, Encodable, Decodable)]
+#[deriving(PartialEq, Copy, Clone, Encodable, Decodable)]
 pub struct Basis2<S> {
     mat: Matrix2<S>
 }
@@ -239,7 +239,7 @@ impl<S: BaseFloat + 'static> Rotation2<S> for Basis2<S> {
 /// inversion, can be implemented more efficiently than the implementations for
 /// `math::Matrix3`. To ensure orthogonality is maintained, the operations have
 /// been restricted to a subeset of those implemented on `Matrix3`.
-#[deriving(PartialEq, Clone, Encodable, Decodable)]
+#[deriving(PartialEq, Copy, Clone, Encodable, Decodable)]
 pub struct Basis3<S> {
     mat: Matrix3<S>
 }

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -21,7 +21,7 @@ use point::{Point, Point3};
 use ray::Ray3;
 use vector::Vector;
 
-#[deriving(Clone, PartialEq, Encodable, Decodable)]
+#[deriving(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub struct Sphere<S> {
     pub center: Point3<S>,
     pub radius: S,

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -76,7 +76,7 @@ pub trait Transform<S: BaseNum, V: Vector<S>, P: Point<S,V>> {
 
 /// A generic transformation consisting of a rotation,
 /// displacement vector and scale amount.
-#[deriving(Encodable, Decodable)]
+#[deriving(Copy, Clone, Encodable, Decodable)]
 pub struct Decomposed<S, V, R> {
     pub scale: S,
     pub rot: R,
@@ -159,7 +159,7 @@ impl<S: BaseFloat, R: fmt::Show + Rotation3<S>> fmt::Show for Decomposed<S,Vecto
 }
 
 /// A homogeneous transformation matrix.
-#[deriving(Encodable, Decodable)]
+#[deriving(Copy, Clone, Encodable, Decodable)]
 pub struct AffineMatrix3<S> {
     pub mat: Matrix4<S>,
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -177,7 +177,7 @@ pub trait Vector<S: BaseNum>: Array1<S> + Zero + One + Neg<Self> {
 // Utility macro for generating associated functions for the vectors
 macro_rules! vec(
     ($Self:ident <$S:ident> { $($field:ident),+ }, $n:expr) => (
-        #[deriving(PartialEq, Eq, Clone, Hash, Encodable, Decodable, Rand)]
+        #[deriving(PartialEq, Eq, Copy, Clone, Hash, Encodable, Decodable, Rand)]
         pub struct $Self<S> { $(pub $field: S),+ }
 
         impl<$S> $Self<$S> {


### PR DESCRIPTION
All structs now derive Copy where it would previously have been inferred.
Deprecated Equiv trait is removed and the function added directly to the Angle trait.
