### PR TITLE
Addressing `look_at` inconsistency

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -93,8 +93,8 @@ impl<S: BaseFloat> Matrix2<S> {
         Matrix2 { x: c0, y: c1 }
     }
 
-    /// Create a transformation matrix that will cause a vector to point at
-    /// `dir`, using `up` for orientation.
+    /// Create a homogeneous transformation matrix that will cause a vector `dir`
+    /// to point towards `Vectors::unit_y()`, using `up` for orientation.
     pub fn look_at(dir: Vector2<S>, up: Vector2<S>) -> Matrix2<S> {
         //TODO: verify look_at 2D
         Matrix2::from_cols(up, dir).transpose()
@@ -126,8 +126,8 @@ impl<S: BaseFloat> Matrix3<S> {
         Matrix3 { x: c0, y: c1, z: c2 }
     }
 
-    /// Create a rotation matrix that will cause a vector to point at
-    /// `dir`, using `up` for orientation.
+    /// Create a homogeneous transformation matrix that will cause a vector `dir`
+    /// to point towards `Vector3::unit_z()`, using `up` for orientation.
     pub fn look_at(dir: Vector3<S>, up: Vector3<S>) -> Matrix3<S> {
         let dir = dir.normalize();
         let side = up.cross(dir).normalize();
@@ -227,9 +227,24 @@ impl<S: BaseFloat> Matrix4<S> {
                      S::zero(), S::zero(), S::zero(), S::one())
     }
 
-    /// Create a homogeneous transformation matrix that will cause a vector to point at
-    /// `dir`, using `up` for orientation.
+    /// Create a transformation matrix that will transform a vector
+    /// `(center-dir)` to point towards `Vector3::unit_z()`, as well as transform
+    /// a point `eye` to `Point3::origin()`, using `up` for orientation.
     pub fn look_at(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Matrix4<S> {
+        let f = (center - eye).normalize();
+        let s = up.cross(f).normalize();
+        let u = f.cross(s).normalize();
+
+        Matrix4::new(s.x.clone(), u.x.clone(), f.x.clone(), S::zero(),
+                     s.y.clone(), u.y.clone(), f.y.clone(), S::zero(),
+                     s.z.clone(), u.z.clone(), f.z.clone(), S::zero(),
+                     -eye.dot(s), -eye.dot(u), -eye.dot(f), S::one())
+    }
+
+    /// Create a transformation matrix that will transform a vector
+    /// `(center-dir)` to point towards `-Vector3::unit_z()`, as well as transform
+    /// a point `eye` to `Point3::origin()`, using `up` for orientation.
+    pub fn look_at_neg_z(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Matrix4<S> {
         let f = (center - eye).normalize();
         let s = f.cross(up).normalize();
         let u = s.cross(f);
@@ -903,6 +918,10 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
     One::one()
   }
 
+  /// Create a transformation that rotates a vector to look at `center` from `eye`,
+  /// using `up` for orientation.
+  /// In addition, a point `eye` would be translated to `Point3::origin()` by the
+  /// resultant matrix.
   fn look_at(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Matrix4<S> {
     Matrix4::look_at(eye, center, up)
   }

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -338,6 +338,23 @@ pub mod matrix3 {
         assert!(Matrix3::from_value(6.0f64).is_diagonal());
     }
 
+    mod look_at {
+        use cgmath::*;
+        use super::*;
+
+        fn check_look_at(dir: Vector3<f64>, up: Vector3<f64>) {
+            let m = Matrix3::look_at(dir, up);
+            assert_relative_eq!(m*dir, Vector3::unit_z());
+        }
+
+        #[test]
+        fn test_look_at() {
+            check_look_at(V.normalize(), Vector3::unit_y());
+            check_look_at(Vector3::unit_x(), Vector3::unit_y());
+            check_look_at(Vector3::unit_y(), Vector3::unit_z());
+        }
+    }
+
     mod from_axis_x {
         use cgmath::*;
 
@@ -779,6 +796,33 @@ pub mod matrix4 {
             let matrix_long = Matrix4::from(matrix_long);
 
             assert_ulps_eq!(matrix_short, matrix_long);
+        }
+    }
+
+    mod lookat {
+        use cgmath::*;
+
+        const A: Point3<f32> = Point3{x:0.0, y:0.0, z:0.0};
+        const B: Point3<f32> = Point3{x:1.0, y:2.0, z:3.0};
+        const C: Point3<f32> = Point3{x:-8.0, y:-7.0, z:6.0};
+        const UP: Vector3<f32> = Vector3{x:0.0, y:-1.0, z:2.0};
+        const LOOK: Vector3<f32> = Vector3{x:0.0, y:0.0, z:1.0};
+        
+        fn check_look_at(eye: Point3<f32>, center: Point3<f32>, up: Vector3<f32>) {
+            let m = Matrix4::look_at(eye, center, up);
+            let mt = <Matrix4<_> as Transform<_>>::look_at(eye, center, up);
+            let dir = (center - eye).normalize();
+            assert_relative_eq!(m.transform_vector(dir), LOOK);
+            assert_relative_eq!(m.transform_point(eye), A);
+            assert_relative_eq!(mt.transform_vector(dir), LOOK);
+            assert_relative_eq!(mt.transform_point(eye), A);
+        }
+
+        #[test]
+        fn test_look_at() {
+            check_look_at(A, B, UP);
+            check_look_at(B, C, UP);
+            check_look_at(A, C, UP);
         }
     }
 }

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -40,10 +40,27 @@ fn test_look_at() {
     let eye = Point3::new(0.0f64, 0.0, -5.0);
     let center = Point3::new(0.0f64, 0.0, 0.0);
     let up = Vector3::new(1.0f64, 0.0, 0.0);
-    let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at(eye, center, up);
+    let tq: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at(eye, center, up);
+    let tb: Decomposed<Vector3<f64>, Basis3<f64>> = Transform::look_at(eye, center, up); 
     let point = Point3::new(1.0f64, 0.0, 0.0);
     let view_point = Point3::new(0.0f64, 1.0, 5.0);
-    assert_ulps_eq!(&t.transform_point(point), &view_point);
+    assert_ulps_eq!(&tq.transform_point(point), &view_point);
+    assert_ulps_eq!(&tb.transform_point(point), &view_point);
+
+    let eye = Point3::new(1.0, 3.0, 5.0);
+    let center = Point3::origin();
+    let up = Vector3::unit_y();
+
+    let trans0: Matrix4<f32> = Decomposed::<Vector3<f32>, Quaternion<f32>>::look_at(eye, center, up)
+        .inverse_transform().unwrap().into();
+    
+    let trans1: Matrix4<f32> = Decomposed::<Vector3<f32>, Basis3<f32>>::look_at(eye, center, up)
+        .inverse_transform().unwrap().into();
+    
+    let trans2: Matrix4<f32> = Matrix4::look_at(eye, center, up)
+        .inverse_transform().unwrap().into();
+    assert_relative_eq!(trans0, trans2, max_relative=0.0001);
+    assert_relative_eq!(trans2, trans1);
 }
 
 #[cfg(feature = "eders")]


### PR DESCRIPTION
 #390  pointed out the inconsistency, specifically of `Matrix4f::look_at()` among other `look_at` methods in the crate.
Reduced form:
```
let eye = Point3::new(0.0, 0.0, 0.0);
let p = Point3::new(1.0, 0.0, 0.0);
let up = vec3(0.0, 1.0, 0.0);

let pt3 = <Matrix3<_> as Transform<_>>::look_at(eye, p, up).transform_point(p);
let pt4 = Matrix4::look_at(eye, p, up).transform_point(p);

assert_relative_ne!(pt3, pt4);
assert_relative_eq!(pt3, Point3::new(0.0, 0.0, 1.0));
assert_relative_eq!(pt4, Point3::new(0.0, 0.0, -1.0));
```

This can be really confusing to the user if she hasn't been notified in advance. Therefore, this PR suggests we either
- address this inconsistency in docs more explicitly, or
- make it consistent with the rest, and introduce a new method `Matrix4::look_at_neg_z` which retains the current functionality of `Matrix4f::look_at`.

Personally I'd prefer the second approach because IMO it'd be nice if we can look at any directions we want conveniently (as `Matrix3::look_at` has to be coupled with yet another translation, to get what `Matrix4::look_at` can provide). However, it does bring breaking changes to the API.

I took the second approach in the PR, with some tests and docs.  Comments appreciated!