### PR TITLE
Replace most usages of BaseFloat with a new trait BaseReal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+ - Relax the `BaseFloat` requirement on most types and functions to a new trait,
+   `BaseReal`. This allows using `cgmath` with number types with no infinity or 
+   NaN values, such as fixed-point arithmetic.
+
 ## [v0.16.1] - 2018-03-21
 
 ### Added
@@ -243,7 +247,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Renamed `SquareMatrix::one` to `SquareMatrix::identity`. `identity` is easier
   to search for,
   and the more common name for the multiplicative identity for matrices.
-- Matrix impls have now been constrained to `S: BaseFloat`.
+- Matrix impls have now been constrained to `S: BaseReal`.
 
 ## [v0.5.0] - 2015-11-20
 

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -15,20 +15,20 @@
 
 //! Angle units for type-safe, self-documenting code.
 
-use std::fmt;
 use std::f64;
+use std::fmt;
 use std::iter;
 use std::ops::*;
 
-use rand::Rng;
-use rand::distributions::{Distribution, Standard};
-use rand::distributions::uniform::SampleUniform;
 use num_traits::{cast, Bounded};
+use rand::distributions::uniform::SampleUniform;
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 use structure::*;
 
 use approx;
-use num::BaseFloat;
+use num::BaseReal;
 
 /// An angle, in radians.
 ///
@@ -48,7 +48,7 @@ pub struct Deg<S>(pub S);
 
 impl<S> From<Rad<S>> for Deg<S>
 where
-    S: BaseFloat,
+    S: BaseReal,
 {
     #[inline]
     fn from(rad: Rad<S>) -> Deg<S> {
@@ -58,7 +58,7 @@ where
 
 impl<S> From<Deg<S>> for Rad<S>
 where
-    S: BaseFloat,
+    S: BaseReal,
 {
     #[inline]
     fn from(deg: Deg<S>) -> Rad<S> {
@@ -68,7 +68,7 @@ where
 
 macro_rules! impl_angle {
     ($Angle:ident, $fmt:expr, $full_turn:expr, $hi:expr) => {
-        impl<S: BaseFloat> Zero for $Angle<S> {
+        impl<S: BaseReal> Zero for $Angle<S> {
             #[inline]
             fn zero() -> $Angle<S> {
                 $Angle(S::zero())
@@ -80,48 +80,79 @@ macro_rules! impl_angle {
             }
         }
 
-        impl<S: BaseFloat> iter::Sum<$Angle<S>> for $Angle<S> {
+        impl<S: BaseReal> iter::Sum<$Angle<S>> for $Angle<S> {
             #[inline]
-            fn sum<I: Iterator<Item=$Angle<S>>>(iter: I) -> $Angle<S> {
+            fn sum<I: Iterator<Item = $Angle<S>>>(iter: I) -> $Angle<S> {
                 iter.fold($Angle::zero(), Add::add)
             }
         }
 
-        impl<'a, S: 'a + BaseFloat> iter::Sum<&'a $Angle<S>> for $Angle<S> {
+        impl<'a, S: 'a + BaseReal> iter::Sum<&'a $Angle<S>> for $Angle<S> {
             #[inline]
-            fn sum<I: Iterator<Item=&'a $Angle<S>>>(iter: I) -> $Angle<S> {
+            fn sum<I: Iterator<Item = &'a $Angle<S>>>(iter: I) -> $Angle<S> {
                 iter.fold($Angle::zero(), Add::add)
             }
         }
 
-        impl<S: BaseFloat> Angle for $Angle<S> {
+        impl<S: BaseReal> Angle for $Angle<S> {
             type Unitless = S;
 
-            #[inline] fn full_turn() -> $Angle<S> { $Angle(cast($full_turn).unwrap()) }
+            #[inline]
+            fn full_turn() -> $Angle<S> {
+                $Angle(cast($full_turn).unwrap())
+            }
 
-            #[inline] fn sin(self) -> S { Rad::from(self).0.sin() }
-            #[inline] fn cos(self) -> S { Rad::from(self).0.cos() }
-            #[inline] fn tan(self) -> S { Rad::from(self).0.tan() }
-            #[inline] fn sin_cos(self) -> (S, S) { Rad::from(self).0.sin_cos() }
+            #[inline]
+            fn sin(self) -> S {
+                Rad::from(self).0.sin()
+            }
+            #[inline]
+            fn cos(self) -> S {
+                Rad::from(self).0.cos()
+            }
+            #[inline]
+            fn tan(self) -> S {
+                Rad::from(self).0.tan()
+            }
+            #[inline]
+            fn sin_cos(self) -> (S, S) {
+                Rad::from(self).0.sin_cos()
+            }
 
-            #[inline] fn asin(a: S) -> $Angle<S> { Rad(a.asin()).into() }
-            #[inline] fn acos(a: S) -> $Angle<S> { Rad(a.acos()).into() }
-            #[inline] fn atan(a: S) -> $Angle<S> { Rad(a.atan()).into() }
-            #[inline] fn atan2(a: S, b: S) -> $Angle<S> { Rad(a.atan2(b)).into() }
+            #[inline]
+            fn asin(a: S) -> $Angle<S> {
+                Rad(a.asin()).into()
+            }
+            #[inline]
+            fn acos(a: S) -> $Angle<S> {
+                Rad(a.acos()).into()
+            }
+            #[inline]
+            fn atan(a: S) -> $Angle<S> {
+                Rad(a.atan()).into()
+            }
+            #[inline]
+            fn atan2(a: S, b: S) -> $Angle<S> {
+                Rad(a.atan2(b)).into()
+            }
         }
 
-        impl<S: BaseFloat> Neg for $Angle<S> {
+        impl<S: BaseReal> Neg for $Angle<S> {
             type Output = $Angle<S>;
 
             #[inline]
-            fn neg(self) -> $Angle<S> { $Angle(-self.0) }
+            fn neg(self) -> $Angle<S> {
+                $Angle(-self.0)
+            }
         }
 
-        impl<'a, S: BaseFloat> Neg for &'a $Angle<S> {
+        impl<'a, S: BaseReal> Neg for &'a $Angle<S> {
             type Output = $Angle<S>;
 
             #[inline]
-            fn neg(self) -> $Angle<S> { $Angle(-self.0) }
+            fn neg(self) -> $Angle<S> {
+                $Angle(-self.0)
+            }
         }
 
         impl<S: Bounded> Bounded for $Angle<S> {
@@ -136,42 +167,42 @@ macro_rules! impl_angle {
             }
         }
 
-        impl_operator!(<S: BaseFloat> Add<$Angle<S> > for $Angle<S> {
-            fn add(lhs, rhs) -> $Angle<S> { $Angle(lhs.0 + rhs.0) }
-        });
-        impl_operator!(<S: BaseFloat> Sub<$Angle<S> > for $Angle<S> {
-            fn sub(lhs, rhs) -> $Angle<S> { $Angle(lhs.0 - rhs.0) }
-        });
-        impl_operator!(<S: BaseFloat> Div<$Angle<S> > for $Angle<S> {
-            fn div(lhs, rhs) -> S { lhs.0 / rhs.0 }
-        });
-        impl_operator!(<S: BaseFloat> Rem<$Angle<S> > for $Angle<S> {
-            fn rem(lhs, rhs) -> $Angle<S> { $Angle(lhs.0 % rhs.0) }
-        });
-        impl_assignment_operator!(<S: BaseFloat> AddAssign<$Angle<S> > for $Angle<S> {
-            fn add_assign(&mut self, other) { self.0 += other.0; }
-        });
-        impl_assignment_operator!(<S: BaseFloat> SubAssign<$Angle<S> > for $Angle<S> {
-            fn sub_assign(&mut self, other) { self.0 -= other.0; }
-        });
-        impl_assignment_operator!(<S: BaseFloat> RemAssign<$Angle<S> > for $Angle<S> {
-            fn rem_assign(&mut self, other) { self.0 %= other.0; }
-        });
+        impl_operator!(<S: BaseReal> Add<$Angle<S> > for $Angle<S> {
+                            fn add(lhs, rhs) -> $Angle<S> { $Angle(lhs.0 + rhs.0) }
+                        });
+        impl_operator!(<S: BaseReal> Sub<$Angle<S> > for $Angle<S> {
+                            fn sub(lhs, rhs) -> $Angle<S> { $Angle(lhs.0 - rhs.0) }
+                        });
+        impl_operator!(<S: BaseReal> Div<$Angle<S> > for $Angle<S> {
+                            fn div(lhs, rhs) -> S { lhs.0 / rhs.0 }
+                        });
+        impl_operator!(<S: BaseReal> Rem<$Angle<S> > for $Angle<S> {
+                            fn rem(lhs, rhs) -> $Angle<S> { $Angle(lhs.0 % rhs.0) }
+                        });
+        impl_assignment_operator!(<S: BaseReal> AddAssign<$Angle<S> > for $Angle<S> {
+                            fn add_assign(&mut self, other) { self.0 += other.0; }
+                        });
+        impl_assignment_operator!(<S: BaseReal> SubAssign<$Angle<S> > for $Angle<S> {
+                            fn sub_assign(&mut self, other) { self.0 -= other.0; }
+                        });
+        impl_assignment_operator!(<S: BaseReal> RemAssign<$Angle<S> > for $Angle<S> {
+                            fn rem_assign(&mut self, other) { self.0 %= other.0; }
+                        });
 
-        impl_operator!(<S: BaseFloat> Mul<S> for $Angle<S> {
-            fn mul(lhs, scalar) -> $Angle<S> { $Angle(lhs.0 * scalar) }
-        });
-        impl_operator!(<S: BaseFloat> Div<S> for $Angle<S> {
-            fn div(lhs, scalar) -> $Angle<S> { $Angle(lhs.0 / scalar) }
-        });
-        impl_assignment_operator!(<S: BaseFloat> MulAssign<S> for $Angle<S> {
-            fn mul_assign(&mut self, scalar) { self.0 *= scalar; }
-        });
-        impl_assignment_operator!(<S: BaseFloat> DivAssign<S> for $Angle<S> {
-            fn div_assign(&mut self, scalar) { self.0 /= scalar; }
-        });
+        impl_operator!(<S: BaseReal> Mul<S> for $Angle<S> {
+                            fn mul(lhs, scalar) -> $Angle<S> { $Angle(lhs.0 * scalar) }
+                        });
+        impl_operator!(<S: BaseReal> Div<S> for $Angle<S> {
+                            fn div(lhs, scalar) -> $Angle<S> { $Angle(lhs.0 / scalar) }
+                        });
+        impl_assignment_operator!(<S: BaseReal> MulAssign<S> for $Angle<S> {
+                            fn mul_assign(&mut self, scalar) { self.0 *= scalar; }
+                        });
+        impl_assignment_operator!(<S: BaseReal> DivAssign<S> for $Angle<S> {
+                            fn div_assign(&mut self, scalar) { self.0 /= scalar; }
+                        });
 
-        impl<S: BaseFloat> approx::AbsDiffEq for $Angle<S> {
+        impl<S: BaseReal> approx::AbsDiffEq for $Angle<S> {
             type Epsilon = S::Epsilon;
 
             #[inline]
@@ -185,19 +216,24 @@ macro_rules! impl_angle {
             }
         }
 
-        impl<S: BaseFloat> approx::RelativeEq for $Angle<S> {
+        impl<S: BaseReal> approx::RelativeEq for $Angle<S> {
             #[inline]
             fn default_max_relative() -> S::Epsilon {
                 S::default_max_relative()
             }
 
             #[inline]
-            fn relative_eq(&self, other: &Self, epsilon: S::Epsilon, max_relative: S::Epsilon) -> bool {
+            fn relative_eq(
+                &self,
+                other: &Self,
+                epsilon: S::Epsilon,
+                max_relative: S::Epsilon,
+            ) -> bool {
                 S::relative_eq(&self.0, &other.0, epsilon, max_relative)
             }
         }
 
-        impl<S: BaseFloat> approx::UlpsEq for $Angle<S> {
+        impl<S: BaseReal> approx::UlpsEq for $Angle<S> {
             #[inline]
             fn default_max_ulps() -> u32 {
                 S::default_max_ulps()
@@ -208,10 +244,12 @@ macro_rules! impl_angle {
                 S::ulps_eq(&self.0, &other.0, epsilon, max_ulps)
             }
         }
-    
-        impl<S> Distribution<$Angle<S>> for Standard 
-            where Standard: Distribution<S>,
-                S: BaseFloat + SampleUniform {
+
+        impl<S> Distribution<$Angle<S>> for Standard
+        where
+            Standard: Distribution<S>,
+            S: BaseReal + SampleUniform,
+        {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $Angle<S> {
                 $Angle(rng.gen_range(cast(-$hi).unwrap(), cast($hi).unwrap()))
@@ -223,7 +261,7 @@ macro_rules! impl_angle {
                 write!(f, $fmt, self.0)
             }
         }
-    }
+    };
 }
 
 impl_angle!(Rad, "{:?} rad", f64::consts::PI * 2.0, f64::consts::PI);

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -13,18 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use num_traits::cast;
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
-use num_traits::cast;
 
 use structure::*;
 
 use angle::Rad;
 use approx;
-use quaternion::Quaternion;
 #[cfg(feature = "mint")]
 use mint;
-use num::BaseFloat;
+use num::BaseReal;
+use quaternion::Quaternion;
 
 /// A set of [Euler angles] representing a rotation in three-dimensional space.
 ///
@@ -100,7 +100,7 @@ impl<A: Angle> Euler<A> {
     }
 }
 
-impl<S: BaseFloat> From<Quaternion<S>> for Euler<Rad<S>> {
+impl<S: BaseReal> From<Quaternion<S>> for Euler<Rad<S>> {
     fn from(src: Quaternion<S>) -> Euler<Rad<S>> {
         let sig: S = cast(0.499).unwrap();
         let two: S = cast(2).unwrap();
@@ -187,8 +187,10 @@ impl<A: Angle> approx::UlpsEq for Euler<A> {
 }
 
 impl<A> Distribution<Euler<A>> for Standard
-    where Standard: Distribution<A>,
-        A: Angle {
+where
+    Standard: Distribution<A>,
+    A: Angle,
+{
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Euler<A> {
         Euler {
             x: rng.gen(),

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::distributions::{Standard, Distribution};
-use rand::Rng;
 use num_traits::{cast, NumCast};
+use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 use std::fmt;
 use std::iter;
 use std::mem;
@@ -27,7 +27,7 @@ use structure::*;
 use angle::Rad;
 use approx;
 use euler::Euler;
-use num::BaseFloat;
+use num::{BaseFloat, BaseReal};
 use point::{Point2, Point3};
 use quaternion::Quaternion;
 use transform::{Transform, Transform2, Transform3};
@@ -81,7 +81,7 @@ pub struct Matrix4<S> {
     pub w: Vector4<S>,
 }
 
-impl<S: BaseFloat> Matrix2<S> {
+impl<S: BaseReal> Matrix2<S> {
     /// Create a new matrix, providing values for each index.
     #[inline]
     pub fn new(c0r0: S, c0r1: S, c1r0: S, c1r1: S) -> Matrix2<S> {
@@ -107,14 +107,16 @@ impl<S: BaseFloat> Matrix2<S> {
 
         Matrix2::new(c, s, -s, c)
     }
+}
 
+impl<S: BaseFloat> Matrix2<S> {
     /// Are all entries in the matrix finite.
     pub fn is_finite(&self) -> bool {
         self.x.is_finite() && self.y.is_finite()
     }
 }
 
-impl<S: BaseFloat> Matrix3<S> {
+impl<S: BaseReal> Matrix3<S> {
     /// Create a new matrix, providing values for each index.
     #[inline]
     #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -211,14 +213,16 @@ impl<S: BaseFloat> Matrix3<S> {
             _1subc * axis.z * axis.z + c,
         )
     }
+}
 
+impl<S: BaseFloat> Matrix3<S> {
     /// Are all entries in the matrix finite.
     pub fn is_finite(&self) -> bool {
         self.x.is_finite() && self.y.is_finite() && self.z.is_finite()
     }
 }
 
-impl<S: BaseFloat> Matrix4<S> {
+impl<S: BaseReal> Matrix4<S> {
     /// Create a new matrix, providing values for each index.
     #[inline]
     #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -368,14 +372,16 @@ impl<S: BaseFloat> Matrix4<S> {
             S::zero(), S::zero(), S::zero(), S::one(),
         )
     }
+}
 
+impl<S: BaseFloat> Matrix4<S> {
     /// Are all entries in the matrix finite.
     pub fn is_finite(&self) -> bool {
         self.w.is_finite() && self.x.is_finite() && self.y.is_finite() && self.z.is_finite()
     }
 }
 
-impl<S: BaseFloat> Zero for Matrix2<S> {
+impl<S: BaseReal> Zero for Matrix2<S> {
     #[inline]
     fn zero() -> Matrix2<S> {
         #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -391,7 +397,7 @@ impl<S: BaseFloat> Zero for Matrix2<S> {
     }
 }
 
-impl<S: BaseFloat> Zero for Matrix3<S> {
+impl<S: BaseReal> Zero for Matrix3<S> {
     #[inline]
     fn zero() -> Matrix3<S> {
         #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -408,7 +414,7 @@ impl<S: BaseFloat> Zero for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> Zero for Matrix4<S> {
+impl<S: BaseReal> Zero for Matrix4<S> {
     #[inline]
     fn zero() -> Matrix4<S> {
         #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -426,40 +432,40 @@ impl<S: BaseFloat> Zero for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> One for Matrix2<S> {
+impl<S: BaseReal> One for Matrix2<S> {
     #[inline]
     fn one() -> Matrix2<S> {
         Matrix2::from_value(S::one())
     }
 }
 
-impl<S: BaseFloat> One for Matrix3<S> {
+impl<S: BaseReal> One for Matrix3<S> {
     #[inline]
     fn one() -> Matrix3<S> {
         Matrix3::from_value(S::one())
     }
 }
 
-impl<S: BaseFloat> One for Matrix4<S> {
+impl<S: BaseReal> One for Matrix4<S> {
     #[inline]
     fn one() -> Matrix4<S> {
         Matrix4::from_value(S::one())
     }
 }
 
-impl<S: BaseFloat> VectorSpace for Matrix2<S> {
+impl<S: BaseReal> VectorSpace for Matrix2<S> {
     type Scalar = S;
 }
 
-impl<S: BaseFloat> VectorSpace for Matrix3<S> {
+impl<S: BaseReal> VectorSpace for Matrix3<S> {
     type Scalar = S;
 }
 
-impl<S: BaseFloat> VectorSpace for Matrix4<S> {
+impl<S: BaseReal> VectorSpace for Matrix4<S> {
     type Scalar = S;
 }
 
-impl<S: BaseFloat> Matrix for Matrix2<S> {
+impl<S: BaseReal> Matrix for Matrix2<S> {
     type Column = Vector2<S>;
     type Row = Vector2<S>;
     type Transpose = Matrix2<S>;
@@ -496,7 +502,7 @@ impl<S: BaseFloat> Matrix for Matrix2<S> {
     }
 }
 
-impl<S: BaseFloat> SquareMatrix for Matrix2<S> {
+impl<S: BaseReal> SquareMatrix for Matrix2<S> {
     type ColumnRow = Vector2<S>;
 
     #[inline]
@@ -557,7 +563,7 @@ impl<S: BaseFloat> SquareMatrix for Matrix2<S> {
     }
 }
 
-impl<S: BaseFloat> Matrix for Matrix3<S> {
+impl<S: BaseReal> Matrix for Matrix3<S> {
     type Column = Vector3<S>;
     type Row = Vector3<S>;
     type Transpose = Matrix3<S>;
@@ -596,7 +602,7 @@ impl<S: BaseFloat> Matrix for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> SquareMatrix for Matrix3<S> {
+impl<S: BaseReal> SquareMatrix for Matrix3<S> {
     type ColumnRow = Vector3<S>;
 
     #[inline]
@@ -653,19 +659,25 @@ impl<S: BaseFloat> SquareMatrix for Matrix3<S> {
     }
 
     fn is_diagonal(&self) -> bool {
-        ulps_eq!(self[0][1], &S::zero()) && ulps_eq!(self[0][2], &S::zero())
-            && ulps_eq!(self[1][0], &S::zero()) && ulps_eq!(self[1][2], &S::zero())
-            && ulps_eq!(self[2][0], &S::zero()) && ulps_eq!(self[2][1], &S::zero())
+        ulps_eq!(self[0][1], &S::zero())
+            && ulps_eq!(self[0][2], &S::zero())
+            && ulps_eq!(self[1][0], &S::zero())
+            && ulps_eq!(self[1][2], &S::zero())
+            && ulps_eq!(self[2][0], &S::zero())
+            && ulps_eq!(self[2][1], &S::zero())
     }
 
     fn is_symmetric(&self) -> bool {
-        ulps_eq!(self[0][1], &self[1][0]) && ulps_eq!(self[0][2], &self[2][0])
-            && ulps_eq!(self[1][0], &self[0][1]) && ulps_eq!(self[1][2], &self[2][1])
-            && ulps_eq!(self[2][0], &self[0][2]) && ulps_eq!(self[2][1], &self[1][2])
+        ulps_eq!(self[0][1], &self[1][0])
+            && ulps_eq!(self[0][2], &self[2][0])
+            && ulps_eq!(self[1][0], &self[0][1])
+            && ulps_eq!(self[1][2], &self[2][1])
+            && ulps_eq!(self[2][0], &self[0][2])
+            && ulps_eq!(self[2][1], &self[1][2])
     }
 }
 
-impl<S: BaseFloat> Matrix for Matrix4<S> {
+impl<S: BaseReal> Matrix for Matrix4<S> {
     type Column = Vector4<S>;
     type Row = Vector4<S>;
     type Transpose = Matrix4<S>;
@@ -706,7 +718,7 @@ impl<S: BaseFloat> Matrix for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> SquareMatrix for Matrix4<S> {
+impl<S: BaseReal> SquareMatrix for Matrix4<S> {
     type ColumnRow = Vector4<S>;
 
     #[inline]
@@ -814,25 +826,37 @@ impl<S: BaseFloat> SquareMatrix for Matrix4<S> {
     }
 
     fn is_diagonal(&self) -> bool {
-        ulps_eq!(self[0][1], &S::zero()) && ulps_eq!(self[0][2], &S::zero())
-            && ulps_eq!(self[0][3], &S::zero()) && ulps_eq!(self[1][0], &S::zero())
-            && ulps_eq!(self[1][2], &S::zero()) && ulps_eq!(self[1][3], &S::zero())
-            && ulps_eq!(self[2][0], &S::zero()) && ulps_eq!(self[2][1], &S::zero())
-            && ulps_eq!(self[2][3], &S::zero()) && ulps_eq!(self[3][0], &S::zero())
-            && ulps_eq!(self[3][1], &S::zero()) && ulps_eq!(self[3][2], &S::zero())
+        ulps_eq!(self[0][1], &S::zero())
+            && ulps_eq!(self[0][2], &S::zero())
+            && ulps_eq!(self[0][3], &S::zero())
+            && ulps_eq!(self[1][0], &S::zero())
+            && ulps_eq!(self[1][2], &S::zero())
+            && ulps_eq!(self[1][3], &S::zero())
+            && ulps_eq!(self[2][0], &S::zero())
+            && ulps_eq!(self[2][1], &S::zero())
+            && ulps_eq!(self[2][3], &S::zero())
+            && ulps_eq!(self[3][0], &S::zero())
+            && ulps_eq!(self[3][1], &S::zero())
+            && ulps_eq!(self[3][2], &S::zero())
     }
 
     fn is_symmetric(&self) -> bool {
-        ulps_eq!(self[0][1], &self[1][0]) && ulps_eq!(self[0][2], &self[2][0])
-            && ulps_eq!(self[0][3], &self[3][0]) && ulps_eq!(self[1][0], &self[0][1])
-            && ulps_eq!(self[1][2], &self[2][1]) && ulps_eq!(self[1][3], &self[3][1])
-            && ulps_eq!(self[2][0], &self[0][2]) && ulps_eq!(self[2][1], &self[1][2])
-            && ulps_eq!(self[2][3], &self[3][2]) && ulps_eq!(self[3][0], &self[0][3])
-            && ulps_eq!(self[3][1], &self[1][3]) && ulps_eq!(self[3][2], &self[2][3])
+        ulps_eq!(self[0][1], &self[1][0])
+            && ulps_eq!(self[0][2], &self[2][0])
+            && ulps_eq!(self[0][3], &self[3][0])
+            && ulps_eq!(self[1][0], &self[0][1])
+            && ulps_eq!(self[1][2], &self[2][1])
+            && ulps_eq!(self[1][3], &self[3][1])
+            && ulps_eq!(self[2][0], &self[0][2])
+            && ulps_eq!(self[2][1], &self[1][2])
+            && ulps_eq!(self[2][3], &self[3][2])
+            && ulps_eq!(self[3][0], &self[0][3])
+            && ulps_eq!(self[3][1], &self[1][3])
+            && ulps_eq!(self[3][2], &self[2][3])
     }
 }
 
-impl<S: BaseFloat> approx::AbsDiffEq for Matrix2<S> {
+impl<S: BaseReal> approx::AbsDiffEq for Matrix2<S> {
     type Epsilon = S::Epsilon;
 
     #[inline]
@@ -847,7 +871,7 @@ impl<S: BaseFloat> approx::AbsDiffEq for Matrix2<S> {
     }
 }
 
-impl<S: BaseFloat> approx::RelativeEq for Matrix2<S> {
+impl<S: BaseReal> approx::RelativeEq for Matrix2<S> {
     #[inline]
     fn default_max_relative() -> S::Epsilon {
         S::default_max_relative()
@@ -860,7 +884,7 @@ impl<S: BaseFloat> approx::RelativeEq for Matrix2<S> {
     }
 }
 
-impl<S: BaseFloat> approx::UlpsEq for Matrix2<S> {
+impl<S: BaseReal> approx::UlpsEq for Matrix2<S> {
     #[inline]
     fn default_max_ulps() -> u32 {
         S::default_max_ulps()
@@ -873,7 +897,7 @@ impl<S: BaseFloat> approx::UlpsEq for Matrix2<S> {
     }
 }
 
-impl<S: BaseFloat> approx::AbsDiffEq for Matrix3<S> {
+impl<S: BaseReal> approx::AbsDiffEq for Matrix3<S> {
     type Epsilon = S::Epsilon;
 
     #[inline]
@@ -889,7 +913,7 @@ impl<S: BaseFloat> approx::AbsDiffEq for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> approx::RelativeEq for Matrix3<S> {
+impl<S: BaseReal> approx::RelativeEq for Matrix3<S> {
     #[inline]
     fn default_max_relative() -> S::Epsilon {
         S::default_max_relative()
@@ -903,7 +927,7 @@ impl<S: BaseFloat> approx::RelativeEq for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> approx::UlpsEq for Matrix3<S> {
+impl<S: BaseReal> approx::UlpsEq for Matrix3<S> {
     #[inline]
     fn default_max_ulps() -> u32 {
         S::default_max_ulps()
@@ -917,7 +941,7 @@ impl<S: BaseFloat> approx::UlpsEq for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> approx::AbsDiffEq for Matrix4<S> {
+impl<S: BaseReal> approx::AbsDiffEq for Matrix4<S> {
     type Epsilon = S::Epsilon;
 
     #[inline]
@@ -934,7 +958,7 @@ impl<S: BaseFloat> approx::AbsDiffEq for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> approx::RelativeEq for Matrix4<S> {
+impl<S: BaseReal> approx::RelativeEq for Matrix4<S> {
     #[inline]
     fn default_max_relative() -> S::Epsilon {
         S::default_max_relative()
@@ -949,7 +973,7 @@ impl<S: BaseFloat> approx::RelativeEq for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> approx::UlpsEq for Matrix4<S> {
+impl<S: BaseReal> approx::UlpsEq for Matrix4<S> {
     #[inline]
     fn default_max_ulps() -> u32 {
         S::default_max_ulps()
@@ -964,7 +988,7 @@ impl<S: BaseFloat> approx::UlpsEq for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> Transform<Point2<S>> for Matrix3<S> {
+impl<S: BaseReal> Transform<Point2<S>> for Matrix3<S> {
     fn one() -> Matrix3<S> {
         One::one()
     }
@@ -991,7 +1015,7 @@ impl<S: BaseFloat> Transform<Point2<S>> for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> Transform<Point3<S>> for Matrix3<S> {
+impl<S: BaseReal> Transform<Point3<S>> for Matrix3<S> {
     fn one() -> Matrix3<S> {
         One::one()
     }
@@ -1018,7 +1042,7 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
+impl<S: BaseReal> Transform<Point3<S>> for Matrix4<S> {
     fn one() -> Matrix4<S> {
         One::one()
     }
@@ -1044,72 +1068,72 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> Transform2<S> for Matrix3<S> {}
+impl<S: BaseReal> Transform2<S> for Matrix3<S> {}
 
-impl<S: BaseFloat> Transform3<S> for Matrix3<S> {}
+impl<S: BaseReal> Transform3<S> for Matrix3<S> {}
 
-impl<S: BaseFloat> Transform3<S> for Matrix4<S> {}
+impl<S: BaseReal> Transform3<S> for Matrix4<S> {}
 
 macro_rules! impl_matrix {
     ($MatrixN:ident, $VectorN:ident { $($field:ident : $row_index:expr),+ }) => {
-        impl_operator!(<S: BaseFloat> Neg for $MatrixN<S> {
+        impl_operator!(<S: BaseReal> Neg for $MatrixN<S> {
             fn neg(matrix) -> $MatrixN<S> { $MatrixN { $($field: -matrix.$field),+ } }
         });
 
-        impl_operator!(<S: BaseFloat> Mul<S> for $MatrixN<S> {
+        impl_operator!(<S: BaseReal> Mul<S> for $MatrixN<S> {
             fn mul(matrix, scalar) -> $MatrixN<S> { $MatrixN { $($field: matrix.$field * scalar),+ } }
         });
-        impl_operator!(<S: BaseFloat> Div<S> for $MatrixN<S> {
+        impl_operator!(<S: BaseReal> Div<S> for $MatrixN<S> {
             fn div(matrix, scalar) -> $MatrixN<S> { $MatrixN { $($field: matrix.$field / scalar),+ } }
         });
-        impl_operator!(<S: BaseFloat> Rem<S> for $MatrixN<S> {
+        impl_operator!(<S: BaseReal> Rem<S> for $MatrixN<S> {
             fn rem(matrix, scalar) -> $MatrixN<S> { $MatrixN { $($field: matrix.$field % scalar),+ } }
         });
-        impl_assignment_operator!(<S: BaseFloat> MulAssign<S> for $MatrixN<S> {
+        impl_assignment_operator!(<S: BaseReal> MulAssign<S> for $MatrixN<S> {
             fn mul_assign(&mut self, scalar) { $(self.$field *= scalar);+ }
         });
-        impl_assignment_operator!(<S: BaseFloat> DivAssign<S> for $MatrixN<S> {
+        impl_assignment_operator!(<S: BaseReal> DivAssign<S> for $MatrixN<S> {
             fn div_assign(&mut self, scalar) { $(self.$field /= scalar);+ }
         });
-        impl_assignment_operator!(<S: BaseFloat> RemAssign<S> for $MatrixN<S> {
+        impl_assignment_operator!(<S: BaseReal> RemAssign<S> for $MatrixN<S> {
             fn rem_assign(&mut self, scalar) { $(self.$field %= scalar);+ }
         });
 
-        impl_operator!(<S: BaseFloat> Add<$MatrixN<S> > for $MatrixN<S> {
+        impl_operator!(<S: BaseReal> Add<$MatrixN<S> > for $MatrixN<S> {
             fn add(lhs, rhs) -> $MatrixN<S> { $MatrixN { $($field: lhs.$field + rhs.$field),+ } }
         });
-        impl_operator!(<S: BaseFloat> Sub<$MatrixN<S> > for $MatrixN<S> {
+        impl_operator!(<S: BaseReal> Sub<$MatrixN<S> > for $MatrixN<S> {
             fn sub(lhs, rhs) -> $MatrixN<S> { $MatrixN { $($field: lhs.$field - rhs.$field),+ } }
         });
-        impl<S: BaseFloat + AddAssign<S>> AddAssign<$MatrixN<S>> for $MatrixN<S> {
+        impl<S: BaseReal + AddAssign<S>> AddAssign<$MatrixN<S>> for $MatrixN<S> {
             fn add_assign(&mut self, other: $MatrixN<S>) { $(self.$field += other.$field);+ }
         }
-        impl<S: BaseFloat + SubAssign<S>> SubAssign<$MatrixN<S>> for $MatrixN<S> {
+        impl<S: BaseReal + SubAssign<S>> SubAssign<$MatrixN<S>> for $MatrixN<S> {
             fn sub_assign(&mut self, other: $MatrixN<S>) { $(self.$field -= other.$field);+ }
         }
 
-        impl<S: BaseFloat> iter::Sum<$MatrixN<S>> for $MatrixN<S> {
+        impl<S: BaseReal> iter::Sum<$MatrixN<S>> for $MatrixN<S> {
             #[inline]
             fn sum<I: Iterator<Item=$MatrixN<S>>>(iter: I) -> $MatrixN<S> {
                 iter.fold($MatrixN::zero(), Add::add)
             }
         }
 
-        impl<'a, S: 'a + BaseFloat> iter::Sum<&'a $MatrixN<S>> for $MatrixN<S> {
+        impl<'a, S: 'a + BaseReal> iter::Sum<&'a $MatrixN<S>> for $MatrixN<S> {
             #[inline]
             fn sum<I: Iterator<Item=&'a $MatrixN<S>>>(iter: I) -> $MatrixN<S> {
                 iter.fold($MatrixN::zero(), Add::add)
             }
         }
 
-        impl<S: BaseFloat> iter::Product for $MatrixN<S> {
+        impl<S: BaseReal> iter::Product for $MatrixN<S> {
             #[inline]
             fn product<I: Iterator<Item=$MatrixN<S>>>(iter: I) -> $MatrixN<S> {
                 iter.fold($MatrixN::identity(), Mul::mul)
             }
         }
 
-        impl<'a, S: 'a + BaseFloat> iter::Product<&'a $MatrixN<S>> for $MatrixN<S> {
+        impl<'a, S: 'a + BaseReal> iter::Product<&'a $MatrixN<S>> for $MatrixN<S> {
             #[inline]
             fn product<I: Iterator<Item=&'a $MatrixN<S>>>(iter: I) -> $MatrixN<S> {
                 iter.fold($MatrixN::identity(), Mul::mul)
@@ -1167,7 +1191,7 @@ impl_matrix!(Matrix4, Vector4 { x: 0, y: 1, z: 2, w: 3 });
 
 macro_rules! impl_mv_operator {
     ($MatrixN:ident, $VectorN:ident { $($field:ident : $row_index:expr),+ }) => {
-        impl_operator!(<S: BaseFloat> Mul<$VectorN<S> > for $MatrixN<S> {
+        impl_operator!(<S: BaseReal> Mul<$VectorN<S> > for $MatrixN<S> {
             fn mul(matrix, vector) -> $VectorN<S> {$VectorN::new($(matrix.row($row_index).dot(vector.clone())),+)}
         });
     }
@@ -1180,20 +1204,20 @@ impl_mv_operator!(Matrix3, Vector3 { x: 0, y: 1, z: 2 });
 impl_mv_operator!(Matrix4, Vector4 { x: 0, y: 1, z: 2, w: 3 });
 
 #[cfg(feature = "simd")]
-impl_operator!(<S: BaseFloat> Mul<Vector4<S> > for Matrix4<S> {
+impl_operator!(<S: BaseReal> Mul<Vector4<S> > for Matrix4<S> {
     fn mul(matrix, vector) -> Vector4<S> {
         matrix[0] * vector[0] + matrix[1] * vector[1] + matrix[2] * vector[2] + matrix[3] * vector[3]
     }
 });
 
-impl_operator!(<S: BaseFloat> Mul<Matrix2<S> > for Matrix2<S> {
+impl_operator!(<S: BaseReal> Mul<Matrix2<S> > for Matrix2<S> {
     fn mul(lhs, rhs) -> Matrix2<S> {
         Matrix2::new(lhs.row(0).dot(rhs[0]), lhs.row(1).dot(rhs[0]),
                      lhs.row(0).dot(rhs[1]), lhs.row(1).dot(rhs[1]))
     }
 });
 
-impl_operator!(<S: BaseFloat> Mul<Matrix3<S> > for Matrix3<S> {
+impl_operator!(<S: BaseReal> Mul<Matrix3<S> > for Matrix3<S> {
     fn mul(lhs, rhs) -> Matrix3<S> {
         Matrix3::new(lhs.row(0).dot(rhs[0]), lhs.row(1).dot(rhs[0]), lhs.row(2).dot(rhs[0]),
                      lhs.row(0).dot(rhs[1]), lhs.row(1).dot(rhs[1]), lhs.row(2).dot(rhs[1]),
@@ -1207,7 +1231,7 @@ impl_operator!(<S: BaseFloat> Mul<Matrix3<S> > for Matrix3<S> {
 // around ~4 times.
 // Update: this should now be a bit more efficient
 
-impl_operator!(<S: BaseFloat> Mul<Matrix4<S> > for Matrix4<S> {
+impl_operator!(<S: BaseReal> Mul<Matrix4<S> > for Matrix4<S> {
     fn mul(lhs, rhs) -> Matrix4<S> {
         {
             let a = lhs[0];
@@ -1227,7 +1251,7 @@ impl_operator!(<S: BaseFloat> Mul<Matrix4<S> > for Matrix4<S> {
 });
 
 macro_rules! index_operators {
-    ($MatrixN:ident<$S:ident>, $n:expr, $Output:ty, $I:ty) => {
+    ($MatrixN:ident < $S:ident > , $n:expr, $Output:ty, $I:ty) => {
         impl<$S> Index<$I> for $MatrixN<$S> {
             type Output = $Output;
 
@@ -1245,7 +1269,7 @@ macro_rules! index_operators {
                 From::from(&mut v[i])
             }
         }
-    }
+    };
 }
 
 index_operators!(Matrix2<S>, 2, Vector2<S>, usize);
@@ -1425,7 +1449,7 @@ mint_conversions!(Matrix3 { x, y, z }, ColumnMatrix3);
 #[cfg(feature = "mint")]
 mint_conversions!(Matrix4 { x, y, z, w }, ColumnMatrix4);
 
-impl<S: BaseFloat> From<Matrix2<S>> for Matrix3<S> {
+impl<S: BaseReal> From<Matrix2<S>> for Matrix3<S> {
     /// Clone the elements of a 2-dimensional matrix into the top-left corner
     /// of a 3-dimensional identity matrix.
     fn from(m: Matrix2<S>) -> Matrix3<S> {
@@ -1438,7 +1462,7 @@ impl<S: BaseFloat> From<Matrix2<S>> for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> From<Matrix2<S>> for Matrix4<S> {
+impl<S: BaseReal> From<Matrix2<S>> for Matrix4<S> {
     /// Clone the elements of a 2-dimensional matrix into the top-left corner
     /// of a 4-dimensional identity matrix.
     fn from(m: Matrix2<S>) -> Matrix4<S> {
@@ -1452,7 +1476,7 @@ impl<S: BaseFloat> From<Matrix2<S>> for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> From<Matrix3<S>> for Matrix4<S> {
+impl<S: BaseReal> From<Matrix3<S>> for Matrix4<S> {
     /// Clone the elements of a 3-dimensional matrix into the top-left corner
     /// of a 4-dimensional identity matrix.
     fn from(m: Matrix3<S>) -> Matrix4<S> {
@@ -1466,7 +1490,7 @@ impl<S: BaseFloat> From<Matrix3<S>> for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> From<Matrix3<S>> for Quaternion<S> {
+impl<S: BaseReal> From<Matrix3<S>> for Quaternion<S> {
     /// Convert the matrix to a quaternion
     fn from(mat: Matrix3<S>) -> Quaternion<S> {
         // http://www.cs.ucr.edu/~vbz/resources/quatut.pdf
@@ -1531,9 +1555,10 @@ impl<S: fmt::Debug> fmt::Debug for Matrix4<S> {
 }
 
 impl<S> Distribution<Matrix2<S>> for Standard
-    where 
-        Standard: Distribution<Vector2<S>>,
-        S: BaseFloat {
+where
+    Standard: Distribution<Vector2<S>>,
+    S: BaseReal,
+{
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Matrix2<S> {
         Matrix2 {
@@ -1544,8 +1569,10 @@ impl<S> Distribution<Matrix2<S>> for Standard
 }
 
 impl<S> Distribution<Matrix3<S>> for Standard
-    where Standard: Distribution<Vector3<S>>,
-        S: BaseFloat {
+where
+    Standard: Distribution<Vector3<S>>,
+    S: BaseReal,
+{
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Matrix3<S> {
         Matrix3 {
@@ -1557,8 +1584,10 @@ impl<S> Distribution<Matrix3<S>> for Standard
 }
 
 impl<S> Distribution<Matrix4<S>> for Standard
-    where Standard: Distribution<Vector4<S>>,
-        S: BaseFloat {
+where
+    Standard: Distribution<Vector4<S>>,
+    S: BaseReal,
+{
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Matrix4<S> {
         Matrix4 {
@@ -1572,7 +1601,7 @@ impl<S> Distribution<Matrix4<S>> for Standard
 
 // Sub procedure for SIMD when dealing with determinant and inversion
 #[inline]
-unsafe fn det_sub_proc_unsafe<S: BaseFloat>(
+unsafe fn det_sub_proc_unsafe<S: BaseReal>(
     m: &Matrix4<S>,
     x: usize,
     y: usize,

--- a/src/num.rs
+++ b/src/num.rs
@@ -18,6 +18,7 @@ use approx;
 use std::fmt;
 use std::ops::*;
 
+use num_traits::real::Real;
 use num_traits::{Float, Num, NumCast};
 
 /// Base numeric types with partial ordering
@@ -53,6 +54,26 @@ where
 }
 
 /// Base floating point types
+pub trait BaseReal:
+    BaseNum
+    + Real
+    + approx::AbsDiffEq<Epsilon = Self>
+    + approx::RelativeEq<Epsilon = Self>
+    + approx::UlpsEq<Epsilon = Self>
+{
+}
+
+impl<T> BaseReal for T
+where
+    T: BaseNum
+        + Real
+        + approx::AbsDiffEq<Epsilon = Self>
+        + approx::RelativeEq<Epsilon = Self>
+        + approx::UlpsEq<Epsilon = Self>,
+{
+}
+
+/// Base floating point types
 pub trait BaseFloat:
     BaseNum
     + Float
@@ -70,4 +91,20 @@ where
         + approx::RelativeEq<Epsilon = Self>
         + approx::UlpsEq<Epsilon = Self>,
 {
+}
+
+#[cfg(test)]
+mod tests {
+    use num::{BaseFloat, BaseReal};
+
+    #[test]
+    fn test_float_impls_real() {
+        #![allow(dead_code)]
+
+        fn real<S: BaseReal>() {}
+
+        fn float<S: BaseFloat>() {
+            real::<S>()
+        }
+    }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -25,7 +25,7 @@ use std::ops::*;
 use structure::*;
 
 use approx;
-use num::{BaseFloat, BaseNum};
+use num::{BaseFloat, BaseNum, BaseReal};
 use vector::{Vector1, Vector2, Vector3, Vector4};
 
 #[cfg(feature = "mint")]
@@ -138,7 +138,7 @@ macro_rules! impl_point {
             }
         }
 
-        impl<S: BaseFloat> MetricSpace for $PointN<S> {
+        impl<S: BaseReal> MetricSpace for $PointN<S> {
             type Metric = S;
 
             #[inline]
@@ -172,7 +172,7 @@ macro_rules! impl_point {
             }
         }
 
-        impl<S: BaseFloat> approx::AbsDiffEq for $PointN<S> {
+        impl<S: BaseReal> approx::AbsDiffEq for $PointN<S> {
             type Epsilon = S::Epsilon;
 
             #[inline]
@@ -188,7 +188,7 @@ macro_rules! impl_point {
             }
         }
 
-        impl<S: BaseFloat> approx::RelativeEq for $PointN<S> {
+        impl<S: BaseReal> approx::RelativeEq for $PointN<S> {
             #[inline]
             fn default_max_relative() -> S::Epsilon {
                 S::default_max_relative()
@@ -200,7 +200,7 @@ macro_rules! impl_point {
             }
         }
 
-        impl<S: BaseFloat> approx::UlpsEq for $PointN<S> {
+        impl<S: BaseReal> approx::UlpsEq for $PointN<S> {
             #[inline]
             fn default_max_ulps() -> u32 {
                 S::default_max_ulps()

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -13,20 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use num_traits::Zero;
 use num_traits::cast;
+use num_traits::Zero;
 
 use structure::Angle;
 
 use angle::Rad;
 use matrix::Matrix4;
-use num::BaseFloat;
+use num::BaseReal;
 
 /// Create a perspective projection matrix.
 ///
 /// This is the equivalent to the [gluPerspective]
 /// (http://www.opengl.org/sdk/docs/man2/xhtml/gluPerspective.xml) function.
-pub fn perspective<S: BaseFloat, A: Into<Rad<S>>>(
+pub fn perspective<S: BaseReal, A: Into<Rad<S>>>(
     fovy: A,
     aspect: S,
     near: S,
@@ -44,7 +44,7 @@ pub fn perspective<S: BaseFloat, A: Into<Rad<S>>>(
 ///
 /// This is the equivalent of the now deprecated [glFrustum]
 /// (http://www.opengl.org/sdk/docs/man2/xhtml/glFrustum.xml) function.
-pub fn frustum<S: BaseFloat>(left: S, right: S, bottom: S, top: S, near: S, far: S) -> Matrix4<S> {
+pub fn frustum<S: BaseReal>(left: S, right: S, bottom: S, top: S, near: S, far: S) -> Matrix4<S> {
     Perspective {
         left: left,
         right: right,
@@ -59,7 +59,7 @@ pub fn frustum<S: BaseFloat>(left: S, right: S, bottom: S, top: S, near: S, far:
 ///
 /// This is the equivalent of the now deprecated [glOrtho]
 /// (http://www.opengl.org/sdk/docs/man2/xhtml/glOrtho.xml) function.
-pub fn ortho<S: BaseFloat>(left: S, right: S, bottom: S, top: S, near: S, far: S) -> Matrix4<S> {
+pub fn ortho<S: BaseReal>(left: S, right: S, bottom: S, top: S, near: S, far: S) -> Matrix4<S> {
     Ortho {
         left: left,
         right: right,
@@ -81,7 +81,7 @@ pub struct PerspectiveFov<S> {
     pub far: S,
 }
 
-impl<S: BaseFloat> PerspectiveFov<S> {
+impl<S: BaseReal> PerspectiveFov<S> {
     pub fn to_perspective(&self) -> Perspective<S> {
         let two: S = cast(2).unwrap();
         let angle = self.fovy / two;
@@ -99,7 +99,7 @@ impl<S: BaseFloat> PerspectiveFov<S> {
     }
 }
 
-impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
+impl<S: BaseReal> From<PerspectiveFov<S>> for Matrix4<S> {
     fn from(persp: PerspectiveFov<S>) -> Matrix4<S> {
         assert!(
             persp.fovy > Rad::zero(),
@@ -178,7 +178,7 @@ pub struct Perspective<S> {
     pub far: S,
 }
 
-impl<S: BaseFloat> From<Perspective<S>> for Matrix4<S> {
+impl<S: BaseReal> From<Perspective<S>> for Matrix4<S> {
     fn from(persp: Perspective<S>) -> Matrix4<S> {
         assert!(
             persp.left <= persp.right,
@@ -243,7 +243,7 @@ pub struct Ortho<S> {
     pub far: S,
 }
 
-impl<S: BaseFloat> From<Ortho<S>> for Matrix4<S> {
+impl<S: BaseReal> From<Ortho<S>> for Matrix4<S> {
     fn from(ortho: Ortho<S>) -> Matrix4<S> {
         let two: S = cast(2).unwrap();
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -17,9 +17,9 @@ use std::iter;
 use std::mem;
 use std::ops::*;
 
+use num_traits::{cast, NumCast};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
-use num_traits::{cast, NumCast};
 
 use structure::*;
 
@@ -27,7 +27,7 @@ use angle::Rad;
 use approx;
 use euler::Euler;
 use matrix::{Matrix3, Matrix4};
-use num::BaseFloat;
+use num::{BaseFloat, BaseReal};
 use point::Point3;
 use rotation::{Basis3, Rotation, Rotation3};
 use vector::Vector3;
@@ -76,7 +76,7 @@ impl Into<Simdf32x4> for Quaternion<f32> {
     }
 }
 
-impl<S: BaseFloat> Quaternion<S> {
+impl<S: BaseReal> Quaternion<S> {
     /// Construct a new quaternion from one scalar component and three
     /// imaginary components.
     #[inline]
@@ -174,13 +174,15 @@ impl<S: BaseFloat> Quaternion<S> {
             (self * scale1 + other * scale2) * Rad::sin(theta).recip()
         }
     }
+}
 
+impl<S: BaseFloat> Quaternion<S> {
     pub fn is_finite(&self) -> bool {
         self.s.is_finite() && self.v.is_finite()
     }
 }
 
-impl<S: BaseFloat> Zero for Quaternion<S> {
+impl<S: BaseReal> Zero for Quaternion<S> {
     #[inline]
     fn zero() -> Quaternion<S> {
         Quaternion::from_sv(S::zero(), Vector3::zero())
@@ -192,46 +194,46 @@ impl<S: BaseFloat> Zero for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> One for Quaternion<S> {
+impl<S: BaseReal> One for Quaternion<S> {
     #[inline]
     fn one() -> Quaternion<S> {
         Quaternion::from_sv(S::one(), Vector3::zero())
     }
 }
 
-impl<S: BaseFloat> iter::Sum<Quaternion<S>> for Quaternion<S> {
+impl<S: BaseReal> iter::Sum<Quaternion<S>> for Quaternion<S> {
     #[inline]
     fn sum<I: Iterator<Item = Quaternion<S>>>(iter: I) -> Quaternion<S> {
         iter.fold(Quaternion::<S>::zero(), Add::add)
     }
 }
 
-impl<'a, S: 'a + BaseFloat> iter::Sum<&'a Quaternion<S>> for Quaternion<S> {
+impl<'a, S: 'a + BaseReal> iter::Sum<&'a Quaternion<S>> for Quaternion<S> {
     #[inline]
     fn sum<I: Iterator<Item = &'a Quaternion<S>>>(iter: I) -> Quaternion<S> {
         iter.fold(Quaternion::<S>::zero(), Add::add)
     }
 }
 
-impl<S: BaseFloat> iter::Product<Quaternion<S>> for Quaternion<S> {
+impl<S: BaseReal> iter::Product<Quaternion<S>> for Quaternion<S> {
     #[inline]
     fn product<I: Iterator<Item = Quaternion<S>>>(iter: I) -> Quaternion<S> {
         iter.fold(Quaternion::<S>::one(), Mul::mul)
     }
 }
 
-impl<'a, S: 'a + BaseFloat> iter::Product<&'a Quaternion<S>> for Quaternion<S> {
+impl<'a, S: 'a + BaseReal> iter::Product<&'a Quaternion<S>> for Quaternion<S> {
     #[inline]
     fn product<I: Iterator<Item = &'a Quaternion<S>>>(iter: I) -> Quaternion<S> {
         iter.fold(Quaternion::<S>::one(), Mul::mul)
     }
 }
 
-impl<S: BaseFloat> VectorSpace for Quaternion<S> {
+impl<S: BaseReal> VectorSpace for Quaternion<S> {
     type Scalar = S;
 }
 
-impl<S: BaseFloat> MetricSpace for Quaternion<S> {
+impl<S: BaseReal> MetricSpace for Quaternion<S> {
     type Metric = S;
 
     #[inline]
@@ -242,7 +244,7 @@ impl<S: BaseFloat> MetricSpace for Quaternion<S> {
 
 impl<S: NumCast + Copy> Quaternion<S> {
     /// Component-wise casting to another type.
-    pub fn cast<T: BaseFloat>(&self) -> Option<Quaternion<T>> {
+    pub fn cast<T: BaseReal>(&self) -> Option<Quaternion<T>> {
         let s = match NumCast::from(self.s) {
             Some(s) => s,
             None => return None,
@@ -256,7 +258,7 @@ impl<S: NumCast + Copy> Quaternion<S> {
 }
 
 #[cfg(not(feature = "simd"))]
-impl<S: BaseFloat> InnerSpace for Quaternion<S> {
+impl<S: BaseReal> InnerSpace for Quaternion<S> {
     #[inline]
     fn dot(self, other: Quaternion<S>) -> S {
         self.s * other.s + self.v.dot(other.v)
@@ -264,7 +266,7 @@ impl<S: BaseFloat> InnerSpace for Quaternion<S> {
 }
 
 #[cfg(feature = "simd")]
-impl<S: BaseFloat> InnerSpace for Quaternion<S> {
+impl<S: BaseReal> InnerSpace for Quaternion<S> {
     #[inline]
     default fn dot(self, other: Quaternion<S>) -> S {
         self.s * other.s + self.v.dot(other.v)
@@ -307,14 +309,14 @@ where
 }
 
 #[cfg(not(feature = "simd"))]
-impl_operator!(<S: BaseFloat> Neg for Quaternion<S> {
+impl_operator!(<S: BaseReal> Neg for Quaternion<S> {
     fn neg(quat) -> Quaternion<S> {
         Quaternion::from_sv(-quat.s, -quat.v)
     }
 });
 
 #[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Neg for Quaternion<S> {
+impl_operator_default!(<S: BaseReal> Neg for Quaternion<S> {
     fn neg(quat) -> Quaternion<S> {
         Quaternion::from_sv(-quat.s, -quat.v)
     }
@@ -330,14 +332,14 @@ impl_operator_simd!{
 }
 
 #[cfg(not(feature = "simd"))]
-impl_operator!(<S: BaseFloat> Mul<S> for Quaternion<S> {
+impl_operator!(<S: BaseReal> Mul<S> for Quaternion<S> {
     fn mul(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s * rhs, lhs.v * rhs)
     }
 });
 
 #[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Mul<S> for Quaternion<S> {
+impl_operator_default!(<S: BaseReal> Mul<S> for Quaternion<S> {
     fn mul(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s * rhs, lhs.v * rhs)
     }
@@ -353,12 +355,12 @@ impl_operator_simd!{@rs
 }
 
 #[cfg(not(feature = "simd"))]
-impl_assignment_operator!(<S: BaseFloat> MulAssign<S> for Quaternion<S> {
+impl_assignment_operator!(<S: BaseReal> MulAssign<S> for Quaternion<S> {
     fn mul_assign(&mut self, scalar) { self.s *= scalar; self.v *= scalar; }
 });
 
 #[cfg(feature = "simd")]
-impl_assignment_operator_default!(<S: BaseFloat> MulAssign<S> for Quaternion<S> {
+impl_assignment_operator_default!(<S: BaseReal> MulAssign<S> for Quaternion<S> {
     fn mul_assign(&mut self, scalar) { self.s *= scalar; self.v *= scalar; }
 });
 
@@ -372,14 +374,14 @@ impl MulAssign<f32> for Quaternion<f32> {
 }
 
 #[cfg(not(feature = "simd"))]
-impl_operator!(<S: BaseFloat> Div<S> for Quaternion<S> {
+impl_operator!(<S: BaseReal> Div<S> for Quaternion<S> {
     fn div(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s / rhs, lhs.v / rhs)
     }
 });
 
 #[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Div<S> for Quaternion<S> {
+impl_operator_default!(<S: BaseReal> Div<S> for Quaternion<S> {
     fn div(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s / rhs, lhs.v / rhs)
     }
@@ -395,12 +397,12 @@ impl_operator_simd!{@rs
 }
 
 #[cfg(not(feature = "simd"))]
-impl_assignment_operator!(<S: BaseFloat> DivAssign<S> for Quaternion<S> {
+impl_assignment_operator!(<S: BaseReal> DivAssign<S> for Quaternion<S> {
     fn div_assign(&mut self, scalar) { self.s /= scalar; self.v /= scalar; }
 });
 
 #[cfg(feature = "simd")]
-impl_assignment_operator_default!(<S: BaseFloat> DivAssign<S> for Quaternion<S> {
+impl_assignment_operator_default!(<S: BaseReal> DivAssign<S> for Quaternion<S> {
     fn div_assign(&mut self, scalar) { self.s /= scalar; self.v /= scalar; }
 });
 
@@ -413,17 +415,17 @@ impl DivAssign<f32> for Quaternion<f32> {
     }
 }
 
-impl_operator!(<S: BaseFloat> Rem<S> for Quaternion<S> {
+impl_operator!(<S: BaseReal> Rem<S> for Quaternion<S> {
     fn rem(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s % rhs, lhs.v % rhs)
     }
 });
 
-impl_assignment_operator!(<S: BaseFloat> RemAssign<S> for Quaternion<S> {
+impl_assignment_operator!(<S: BaseReal> RemAssign<S> for Quaternion<S> {
     fn rem_assign(&mut self, scalar) { self.s %= scalar; self.v %= scalar; }
 });
 
-impl_operator!(<S: BaseFloat> Mul<Vector3<S> > for Quaternion<S> {
+impl_operator!(<S: BaseReal> Mul<Vector3<S> > for Quaternion<S> {
     fn mul(lhs, rhs) -> Vector3<S> {{
         let rhs = rhs.clone();
         let two: S = cast(2i8).unwrap();
@@ -433,14 +435,14 @@ impl_operator!(<S: BaseFloat> Mul<Vector3<S> > for Quaternion<S> {
 });
 
 #[cfg(not(feature = "simd"))]
-impl_operator!(<S: BaseFloat> Add<Quaternion<S> > for Quaternion<S> {
+impl_operator!(<S: BaseReal> Add<Quaternion<S> > for Quaternion<S> {
     fn add(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s + rhs.s, lhs.v + rhs.v)
     }
 });
 
 #[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Add<Quaternion<S> > for Quaternion<S> {
+impl_operator_default!(<S: BaseReal> Add<Quaternion<S> > for Quaternion<S> {
     fn add(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s + rhs.s, lhs.v + rhs.v)
     }
@@ -456,12 +458,12 @@ impl_operator_simd!{
 }
 
 #[cfg(not(feature = "simd"))]
-impl_assignment_operator!(<S: BaseFloat> AddAssign<Quaternion<S> > for Quaternion<S> {
+impl_assignment_operator!(<S: BaseReal> AddAssign<Quaternion<S> > for Quaternion<S> {
     fn add_assign(&mut self, other) { self.s += other.s; self.v += other.v; }
 });
 
 #[cfg(feature = "simd")]
-impl_assignment_operator_default!(<S: BaseFloat> AddAssign<Quaternion<S> > for Quaternion<S> {
+impl_assignment_operator_default!(<S: BaseReal> AddAssign<Quaternion<S> > for Quaternion<S> {
     fn add_assign(&mut self, other) { self.s += other.s; self.v += other.v; }
 });
 
@@ -476,14 +478,14 @@ impl AddAssign for Quaternion<f32> {
 }
 
 #[cfg(not(feature = "simd"))]
-impl_operator!(<S: BaseFloat> Sub<Quaternion<S> > for Quaternion<S> {
+impl_operator!(<S: BaseReal> Sub<Quaternion<S> > for Quaternion<S> {
     fn sub(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s - rhs.s, lhs.v - rhs.v)
     }
 });
 
 #[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Sub<Quaternion<S> > for Quaternion<S> {
+impl_operator_default!(<S: BaseReal> Sub<Quaternion<S> > for Quaternion<S> {
     fn sub(lhs, rhs) -> Quaternion<S> {
         Quaternion::from_sv(lhs.s - rhs.s, lhs.v - rhs.v)
     }
@@ -499,12 +501,12 @@ impl_operator_simd!{
 }
 
 #[cfg(not(feature = "simd"))]
-impl_assignment_operator!(<S: BaseFloat> SubAssign<Quaternion<S> > for Quaternion<S> {
+impl_assignment_operator!(<S: BaseReal> SubAssign<Quaternion<S> > for Quaternion<S> {
     fn sub_assign(&mut self, other) { self.s -= other.s; self.v -= other.v; }
 });
 
 #[cfg(feature = "simd")]
-impl_assignment_operator_default!(<S: BaseFloat> SubAssign<Quaternion<S> > for Quaternion<S> {
+impl_assignment_operator_default!(<S: BaseReal> SubAssign<Quaternion<S> > for Quaternion<S> {
     fn sub_assign(&mut self, other) { self.s -= other.s; self.v -= other.v; }
 });
 
@@ -519,7 +521,7 @@ impl SubAssign for Quaternion<f32> {
 }
 
 #[cfg(not(feature = "simd"))]
-impl_operator!(<S: BaseFloat> Mul<Quaternion<S> > for Quaternion<S> {
+impl_operator!(<S: BaseReal> Mul<Quaternion<S> > for Quaternion<S> {
     fn mul(lhs, rhs) -> Quaternion<S> {
         Quaternion::new(
             lhs.s * rhs.s - lhs.v.x * rhs.v.x - lhs.v.y * rhs.v.y - lhs.v.z * rhs.v.z,
@@ -531,7 +533,7 @@ impl_operator!(<S: BaseFloat> Mul<Quaternion<S> > for Quaternion<S> {
 });
 
 #[cfg(feature = "simd")]
-impl_operator_default!(<S: BaseFloat> Mul<Quaternion<S> > for Quaternion<S> {
+impl_operator_default!(<S: BaseReal> Mul<Quaternion<S> > for Quaternion<S> {
     fn mul(lhs, rhs) -> Quaternion<S> {
         Quaternion::new(
             lhs.s * rhs.s - lhs.v.x * rhs.v.x - lhs.v.y * rhs.v.y - lhs.v.z * rhs.v.z,
@@ -566,20 +568,20 @@ impl_operator_simd!{
 macro_rules! impl_scalar_mul {
     ($S:ident) => {
         impl_operator!(Mul<Quaternion<$S>> for $S {
-            fn mul(scalar, quat) -> Quaternion<$S> {
-                Quaternion::from_sv(scalar * quat.s, scalar * quat.v)
-            }
-        });
+                                    fn mul(scalar, quat) -> Quaternion<$S> {
+                                        Quaternion::from_sv(scalar * quat.s, scalar * quat.v)
+                                    }
+                                });
     };
 }
 
 macro_rules! impl_scalar_div {
     ($S:ident) => {
         impl_operator!(Div<Quaternion<$S>> for $S {
-            fn div(scalar, quat) -> Quaternion<$S> {
-                Quaternion::from_sv(scalar / quat.s, scalar / quat.v)
-            }
-        });
+                                    fn div(scalar, quat) -> Quaternion<$S> {
+                                        Quaternion::from_sv(scalar / quat.s, scalar / quat.v)
+                                    }
+                                });
     };
 }
 
@@ -588,7 +590,7 @@ impl_scalar_mul!(f64);
 impl_scalar_div!(f32);
 impl_scalar_div!(f64);
 
-impl<S: BaseFloat> approx::AbsDiffEq for Quaternion<S> {
+impl<S: BaseReal> approx::AbsDiffEq for Quaternion<S> {
     type Epsilon = S::Epsilon;
 
     #[inline]
@@ -603,7 +605,7 @@ impl<S: BaseFloat> approx::AbsDiffEq for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> approx::RelativeEq for Quaternion<S> {
+impl<S: BaseReal> approx::RelativeEq for Quaternion<S> {
     #[inline]
     fn default_max_relative() -> S::Epsilon {
         S::default_max_relative()
@@ -616,7 +618,7 @@ impl<S: BaseFloat> approx::RelativeEq for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> approx::UlpsEq for Quaternion<S> {
+impl<S: BaseReal> approx::UlpsEq for Quaternion<S> {
     #[inline]
     fn default_max_ulps() -> u32 {
         S::default_max_ulps()
@@ -629,7 +631,7 @@ impl<S: BaseFloat> approx::UlpsEq for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> From<Quaternion<S>> for Matrix3<S> {
+impl<S: BaseReal> From<Quaternion<S>> for Matrix3<S> {
     /// Convert the quaternion to a 3 x 3 rotation matrix.
     fn from(quat: Quaternion<S>) -> Matrix3<S> {
         let x2 = quat.v.x + quat.v.x;
@@ -657,7 +659,7 @@ impl<S: BaseFloat> From<Quaternion<S>> for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> From<Quaternion<S>> for Matrix4<S> {
+impl<S: BaseReal> From<Quaternion<S>> for Matrix4<S> {
     /// Convert the quaternion to a 4 x 4 rotation matrix.
     fn from(quat: Quaternion<S>) -> Matrix4<S> {
         let x2 = quat.v.x + quat.v.x;
@@ -688,14 +690,14 @@ impl<S: BaseFloat> From<Quaternion<S>> for Matrix4<S> {
 
 // Quaternion Rotation impls
 
-impl<S: BaseFloat> From<Quaternion<S>> for Basis3<S> {
+impl<S: BaseReal> From<Quaternion<S>> for Basis3<S> {
     #[inline]
     fn from(quat: Quaternion<S>) -> Basis3<S> {
         Basis3::from_quaternion(&quat)
     }
 }
 
-impl<S: BaseFloat> Rotation<Point3<S>> for Quaternion<S> {
+impl<S: BaseReal> Rotation<Point3<S>> for Quaternion<S> {
     #[inline]
     fn look_at(dir: Vector3<S>, up: Vector3<S>) -> Quaternion<S> {
         Matrix3::look_at(dir, up).into()
@@ -738,7 +740,7 @@ impl<S: BaseFloat> Rotation<Point3<S>> for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> Rotation3<S> for Quaternion<S> {
+impl<S: BaseReal> Rotation3<S> for Quaternion<S> {
     #[inline]
     fn from_axis_angle<A: Into<Rad<S>>>(axis: Vector3<S>, angle: A) -> Quaternion<S> {
         let (s, c) = Rad::sin_cos(angle.into() * cast(0.5f64).unwrap());
@@ -746,7 +748,7 @@ impl<S: BaseFloat> Rotation3<S> for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> Into<[S; 4]> for Quaternion<S> {
+impl<S: BaseReal> Into<[S; 4]> for Quaternion<S> {
     #[inline]
     fn into(self) -> [S; 4] {
         match self.into() {
@@ -755,42 +757,42 @@ impl<S: BaseFloat> Into<[S; 4]> for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> AsRef<[S; 4]> for Quaternion<S> {
+impl<S: BaseReal> AsRef<[S; 4]> for Quaternion<S> {
     #[inline]
     fn as_ref(&self) -> &[S; 4] {
         unsafe { mem::transmute(self) }
     }
 }
 
-impl<S: BaseFloat> AsMut<[S; 4]> for Quaternion<S> {
+impl<S: BaseReal> AsMut<[S; 4]> for Quaternion<S> {
     #[inline]
     fn as_mut(&mut self) -> &mut [S; 4] {
         unsafe { mem::transmute(self) }
     }
 }
 
-impl<S: BaseFloat> From<[S; 4]> for Quaternion<S> {
+impl<S: BaseReal> From<[S; 4]> for Quaternion<S> {
     #[inline]
     fn from(v: [S; 4]) -> Quaternion<S> {
         Quaternion::new(v[0], v[1], v[2], v[3])
     }
 }
 
-impl<'a, S: BaseFloat> From<&'a [S; 4]> for &'a Quaternion<S> {
+impl<'a, S: BaseReal> From<&'a [S; 4]> for &'a Quaternion<S> {
     #[inline]
     fn from(v: &'a [S; 4]) -> &'a Quaternion<S> {
         unsafe { mem::transmute(v) }
     }
 }
 
-impl<'a, S: BaseFloat> From<&'a mut [S; 4]> for &'a mut Quaternion<S> {
+impl<'a, S: BaseReal> From<&'a mut [S; 4]> for &'a mut Quaternion<S> {
     #[inline]
     fn from(v: &'a mut [S; 4]) -> &'a mut Quaternion<S> {
         unsafe { mem::transmute(v) }
     }
 }
 
-impl<S: BaseFloat> Into<(S, S, S, S)> for Quaternion<S> {
+impl<S: BaseReal> Into<(S, S, S, S)> for Quaternion<S> {
     #[inline]
     fn into(self) -> (S, S, S, S) {
         match self {
@@ -802,21 +804,21 @@ impl<S: BaseFloat> Into<(S, S, S, S)> for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> AsRef<(S, S, S, S)> for Quaternion<S> {
+impl<S: BaseReal> AsRef<(S, S, S, S)> for Quaternion<S> {
     #[inline]
     fn as_ref(&self) -> &(S, S, S, S) {
         unsafe { mem::transmute(self) }
     }
 }
 
-impl<S: BaseFloat> AsMut<(S, S, S, S)> for Quaternion<S> {
+impl<S: BaseReal> AsMut<(S, S, S, S)> for Quaternion<S> {
     #[inline]
     fn as_mut(&mut self) -> &mut (S, S, S, S) {
         unsafe { mem::transmute(self) }
     }
 }
 
-impl<S: BaseFloat> From<(S, S, S, S)> for Quaternion<S> {
+impl<S: BaseReal> From<(S, S, S, S)> for Quaternion<S> {
     #[inline]
     fn from(v: (S, S, S, S)) -> Quaternion<S> {
         match v {
@@ -825,14 +827,14 @@ impl<S: BaseFloat> From<(S, S, S, S)> for Quaternion<S> {
     }
 }
 
-impl<'a, S: BaseFloat> From<&'a (S, S, S, S)> for &'a Quaternion<S> {
+impl<'a, S: BaseReal> From<&'a (S, S, S, S)> for &'a Quaternion<S> {
     #[inline]
     fn from(v: &'a (S, S, S, S)) -> &'a Quaternion<S> {
         unsafe { mem::transmute(v) }
     }
 }
 
-impl<'a, S: BaseFloat> From<&'a mut (S, S, S, S)> for &'a mut Quaternion<S> {
+impl<'a, S: BaseReal> From<&'a mut (S, S, S, S)> for &'a mut Quaternion<S> {
     #[inline]
     fn from(v: &'a mut (S, S, S, S)) -> &'a mut Quaternion<S> {
         unsafe { mem::transmute(v) }
@@ -841,22 +843,24 @@ impl<'a, S: BaseFloat> From<&'a mut (S, S, S, S)> for &'a mut Quaternion<S> {
 
 macro_rules! index_operators {
     ($S:ident, $Output:ty, $I:ty) => {
-        impl<$S: BaseFloat> Index<$I> for Quaternion<$S> {
+        impl<$S: BaseReal> Index<$I> for Quaternion<$S> {
             type Output = $Output;
 
             #[inline]
             fn index<'a>(&'a self, i: $I) -> &'a $Output {
-                let v: &[$S; 4] = self.as_ref(); &v[i]
+                let v: &[$S; 4] = self.as_ref();
+                &v[i]
             }
         }
 
-        impl<$S: BaseFloat> IndexMut<$I> for Quaternion<$S> {
+        impl<$S: BaseReal> IndexMut<$I> for Quaternion<$S> {
             #[inline]
             fn index_mut<'a>(&'a mut self, i: $I) -> &'a mut $Output {
-                let v: &mut [$S; 4] = self.as_mut(); &mut v[i]
+                let v: &mut [$S; 4] = self.as_mut();
+                &mut v[i]
             }
         }
-    }
+    };
 }
 
 index_operators!(S, S, usize);
@@ -865,10 +869,12 @@ index_operators!(S, [S], RangeTo<usize>);
 index_operators!(S, [S], RangeFrom<usize>);
 index_operators!(S, [S], RangeFull);
 
-impl<S> Distribution<Quaternion<S>> for Standard 
-    where Standard: Distribution<S>,
-        Standard: Distribution<Vector3<S>>,
-        S: BaseFloat {
+impl<S> Distribution<Quaternion<S>> for Standard
+where
+    Standard: Distribution<S>,
+    Standard: Distribution<Vector3<S>>,
+    S: BaseReal,
+{
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Quaternion<S> {
         Quaternion::from_sv(rng.gen(), rng.gen())

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -23,7 +23,7 @@ use angle::Rad;
 use approx;
 use euler::Euler;
 use matrix::{Matrix2, Matrix3};
-use num::BaseFloat;
+use num::BaseReal;
 use point::{Point2, Point3};
 use quaternion::Quaternion;
 use vector::{Vector2, Vector3};
@@ -36,7 +36,7 @@ where
     Self: approx::AbsDiffEq<Epsilon = P::Scalar>,
     Self: approx::RelativeEq<Epsilon = P::Scalar>,
     Self: approx::UlpsEq<Epsilon = P::Scalar>,
-    P::Scalar: BaseFloat,
+    P::Scalar: BaseReal,
     Self: iter::Product<Self>,
 {
     /// Create a rotation to a given direction with an 'up' vector.
@@ -62,17 +62,20 @@ where
 }
 
 /// A two-dimensional rotation.
-pub trait Rotation2<S: BaseFloat>
-    : Rotation<Point2<S>> + Into<Matrix2<S>> + Into<Basis2<S>> {
+pub trait Rotation2<S: BaseReal>: Rotation<Point2<S>> + Into<Matrix2<S>> + Into<Basis2<S>> {
     /// Create a rotation by a given angle. Thus is a redundant case of both
     /// from_axis_angle() and from_euler() for 2D space.
     fn from_angle<A: Into<Rad<S>>>(theta: A) -> Self;
 }
 
 /// A three-dimensional rotation.
-pub trait Rotation3<S: BaseFloat>
-    : Rotation<Point3<S>> + Into<Matrix3<S>> + Into<Basis3<S>> + Into<Quaternion<S>> + From<Euler<Rad<S>>>
-    {
+pub trait Rotation3<S: BaseReal>:
+    Rotation<Point3<S>>
+    + Into<Matrix3<S>>
+    + Into<Basis3<S>>
+    + Into<Quaternion<S>>
+    + From<Euler<Rad<S>>>
+{
     /// Create a rotation using an angle around a given axis.
     ///
     /// The specified axis **must be normalized**, or it represents an invalid rotation.
@@ -146,35 +149,35 @@ pub struct Basis2<S> {
     mat: Matrix2<S>,
 }
 
-impl<S: BaseFloat> AsRef<Matrix2<S>> for Basis2<S> {
+impl<S: BaseReal> AsRef<Matrix2<S>> for Basis2<S> {
     #[inline]
     fn as_ref(&self) -> &Matrix2<S> {
         &self.mat
     }
 }
 
-impl<S: BaseFloat> From<Basis2<S>> for Matrix2<S> {
+impl<S: BaseReal> From<Basis2<S>> for Matrix2<S> {
     #[inline]
     fn from(b: Basis2<S>) -> Matrix2<S> {
         b.mat
     }
 }
 
-impl<S: BaseFloat> iter::Product<Basis2<S>> for Basis2<S> {
+impl<S: BaseReal> iter::Product<Basis2<S>> for Basis2<S> {
     #[inline]
     fn product<I: Iterator<Item = Basis2<S>>>(iter: I) -> Basis2<S> {
         iter.fold(Basis2::one(), Mul::mul)
     }
 }
 
-impl<'a, S: 'a + BaseFloat> iter::Product<&'a Basis2<S>> for Basis2<S> {
+impl<'a, S: 'a + BaseReal> iter::Product<&'a Basis2<S>> for Basis2<S> {
     #[inline]
     fn product<I: Iterator<Item = &'a Basis2<S>>>(iter: I) -> Basis2<S> {
         iter.fold(Basis2::one(), Mul::mul)
     }
 }
 
-impl<S: BaseFloat> Rotation<Point2<S>> for Basis2<S> {
+impl<S: BaseReal> Rotation<Point2<S>> for Basis2<S> {
     #[inline]
     fn look_at(dir: Vector2<S>, up: Vector2<S>) -> Basis2<S> {
         Basis2 {
@@ -202,7 +205,7 @@ impl<S: BaseFloat> Rotation<Point2<S>> for Basis2<S> {
     }
 }
 
-impl<S: BaseFloat> One for Basis2<S> {
+impl<S: BaseReal> One for Basis2<S> {
     #[inline]
     fn one() -> Basis2<S> {
         Basis2 {
@@ -211,11 +214,11 @@ impl<S: BaseFloat> One for Basis2<S> {
     }
 }
 
-impl_operator!(<S: BaseFloat> Mul<Basis2<S> > for Basis2<S> {
+impl_operator!(<S: BaseReal> Mul<Basis2<S> > for Basis2<S> {
     fn mul(lhs, rhs) -> Basis2<S> { Basis2 { mat: lhs.mat * rhs.mat  } }
 });
 
-impl<S: BaseFloat> approx::AbsDiffEq for Basis2<S> {
+impl<S: BaseReal> approx::AbsDiffEq for Basis2<S> {
     type Epsilon = S::Epsilon;
 
     #[inline]
@@ -229,7 +232,7 @@ impl<S: BaseFloat> approx::AbsDiffEq for Basis2<S> {
     }
 }
 
-impl<S: BaseFloat> approx::RelativeEq for Basis2<S> {
+impl<S: BaseReal> approx::RelativeEq for Basis2<S> {
     #[inline]
     fn default_max_relative() -> S::Epsilon {
         S::default_max_relative()
@@ -241,7 +244,7 @@ impl<S: BaseFloat> approx::RelativeEq for Basis2<S> {
     }
 }
 
-impl<S: BaseFloat> approx::UlpsEq for Basis2<S> {
+impl<S: BaseReal> approx::UlpsEq for Basis2<S> {
     #[inline]
     fn default_max_ulps() -> u32 {
         S::default_max_ulps()
@@ -253,7 +256,7 @@ impl<S: BaseFloat> approx::UlpsEq for Basis2<S> {
     }
 }
 
-impl<S: BaseFloat> Rotation2<S> for Basis2<S> {
+impl<S: BaseReal> Rotation2<S> for Basis2<S> {
     fn from_angle<A: Into<Rad<S>>>(theta: A) -> Basis2<S> {
         Basis2 {
             mat: Matrix2::from_angle(theta),
@@ -280,7 +283,7 @@ pub struct Basis3<S> {
     mat: Matrix3<S>,
 }
 
-impl<S: BaseFloat> Basis3<S> {
+impl<S: BaseReal> Basis3<S> {
     /// Create a new rotation matrix from a quaternion.
     #[inline]
     pub fn from_quaternion(quaternion: &Quaternion<S>) -> Basis3<S> {
@@ -297,35 +300,35 @@ impl<S> AsRef<Matrix3<S>> for Basis3<S> {
     }
 }
 
-impl<S: BaseFloat> From<Basis3<S>> for Matrix3<S> {
+impl<S: BaseReal> From<Basis3<S>> for Matrix3<S> {
     #[inline]
     fn from(b: Basis3<S>) -> Matrix3<S> {
         b.mat
     }
 }
 
-impl<S: BaseFloat> From<Basis3<S>> for Quaternion<S> {
+impl<S: BaseReal> From<Basis3<S>> for Quaternion<S> {
     #[inline]
     fn from(b: Basis3<S>) -> Quaternion<S> {
         b.mat.into()
     }
 }
 
-impl<S: BaseFloat> iter::Product<Basis3<S>> for Basis3<S> {
+impl<S: BaseReal> iter::Product<Basis3<S>> for Basis3<S> {
     #[inline]
     fn product<I: Iterator<Item = Basis3<S>>>(iter: I) -> Basis3<S> {
         iter.fold(Basis3::one(), Mul::mul)
     }
 }
 
-impl<'a, S: 'a + BaseFloat> iter::Product<&'a Basis3<S>> for Basis3<S> {
+impl<'a, S: 'a + BaseReal> iter::Product<&'a Basis3<S>> for Basis3<S> {
     #[inline]
     fn product<I: Iterator<Item = &'a Basis3<S>>>(iter: I) -> Basis3<S> {
         iter.fold(Basis3::one(), Mul::mul)
     }
 }
 
-impl<S: BaseFloat> Rotation<Point3<S>> for Basis3<S> {
+impl<S: BaseReal> Rotation<Point3<S>> for Basis3<S> {
     #[inline]
     fn look_at(dir: Vector3<S>, up: Vector3<S>) -> Basis3<S> {
         Basis3 {
@@ -354,7 +357,7 @@ impl<S: BaseFloat> Rotation<Point3<S>> for Basis3<S> {
     }
 }
 
-impl<S: BaseFloat> One for Basis3<S> {
+impl<S: BaseReal> One for Basis3<S> {
     #[inline]
     fn one() -> Basis3<S> {
         Basis3 {
@@ -363,11 +366,11 @@ impl<S: BaseFloat> One for Basis3<S> {
     }
 }
 
-impl_operator!(<S: BaseFloat> Mul<Basis3<S> > for Basis3<S> {
+impl_operator!(<S: BaseReal> Mul<Basis3<S> > for Basis3<S> {
     fn mul(lhs, rhs) -> Basis3<S> { Basis3 { mat: lhs.mat * rhs.mat  } }
 });
 
-impl<S: BaseFloat> approx::AbsDiffEq for Basis3<S> {
+impl<S: BaseReal> approx::AbsDiffEq for Basis3<S> {
     type Epsilon = S::Epsilon;
 
     #[inline]
@@ -381,7 +384,7 @@ impl<S: BaseFloat> approx::AbsDiffEq for Basis3<S> {
     }
 }
 
-impl<S: BaseFloat> approx::RelativeEq for Basis3<S> {
+impl<S: BaseReal> approx::RelativeEq for Basis3<S> {
     #[inline]
     fn default_max_relative() -> S::Epsilon {
         S::default_max_relative()
@@ -393,7 +396,7 @@ impl<S: BaseFloat> approx::RelativeEq for Basis3<S> {
     }
 }
 
-impl<S: BaseFloat> approx::UlpsEq for Basis3<S> {
+impl<S: BaseReal> approx::UlpsEq for Basis3<S> {
     #[inline]
     fn default_max_ulps() -> u32 {
         S::default_max_ulps()
@@ -405,7 +408,7 @@ impl<S: BaseFloat> approx::UlpsEq for Basis3<S> {
     }
 }
 
-impl<S: BaseFloat> Rotation3<S> for Basis3<S> {
+impl<S: BaseReal> Rotation3<S> for Basis3<S> {
     fn from_axis_angle<A: Into<Rad<S>>>(axis: Vector3<S>, angle: A) -> Basis3<S> {
         Basis3 {
             mat: Matrix3::from_axis_angle(axis, angle),

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -15,7 +15,8 @@
 
 //! Generic algebraic structures
 
-use num_traits::{cast, Float};
+use num_traits::cast;
+use num_traits::real::Real;
 use std::cmp;
 use std::iter;
 use std::ops::*;
@@ -23,7 +24,7 @@ use std::ops::*;
 use approx;
 
 use angle::Rad;
-use num::{BaseFloat, BaseNum};
+use num::{BaseFloat, BaseNum, BaseReal};
 
 pub use num_traits::{Bounded, One, Zero};
 
@@ -188,7 +189,7 @@ where
 /// Examples are vectors, points, and quaternions.
 pub trait MetricSpace: Sized {
     /// The metric to be returned by the `distance` function.
-    type Metric: BaseFloat;
+    type Metric: BaseReal;
 
     /// Returns the squared distance.
     ///
@@ -199,7 +200,7 @@ pub trait MetricSpace: Sized {
 
     /// The distance between two values.
     fn distance(self, other: Self) -> Self::Metric {
-        Float::sqrt(Self::distance2(self, other))
+        Real::sqrt(Self::distance2(self, other))
     }
 }
 
@@ -213,7 +214,7 @@ pub trait MetricSpace: Sized {
 pub trait InnerSpace: VectorSpace
 where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
-    <Self as VectorSpace>::Scalar: BaseFloat,
+    <Self as VectorSpace>::Scalar: BaseReal,
     Self: MetricSpace<Metric = <Self as VectorSpace>::Scalar>,
     // Self: approx::AbsDiffEq<Epsilon = <Self as VectorSpace>::Scalar>,
     // Self: approx::RelativeEq<Epsilon = <Self as VectorSpace>::Scalar>,
@@ -241,7 +242,7 @@ where
     /// The distance from the tail to the tip of the vector.
     #[inline]
     fn magnitude(self) -> Self::Scalar {
-        Float::sqrt(self.magnitude2())
+        Real::sqrt(self.magnitude2())
     }
 
     /// Returns the angle between two vectors in radians.
@@ -427,7 +428,7 @@ where
 /// see `SquareMatrix`.
 pub trait Matrix: VectorSpace
 where
-    Self::Scalar: BaseFloat,
+    Self::Scalar: BaseReal,
 
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     Self: Index<usize, Output = <Self as Matrix>::Column>,
@@ -482,7 +483,7 @@ where
 /// A column-major major matrix where the rows and column vectors are of the same dimensions.
 pub trait SquareMatrix
 where
-    Self::Scalar: BaseFloat,
+    Self::Scalar: BaseReal,
 
     Self: One,
     Self: iter::Product<Self>,
@@ -590,7 +591,7 @@ where
 
     Self: iter::Sum,
 {
-    type Unitless: BaseFloat;
+    type Unitless: BaseReal;
 
     /// Return the angle, normalized to the range `[0, full_turn)`.
     #[inline]

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -17,7 +17,7 @@ use structure::*;
 
 use approx;
 use matrix::{Matrix2, Matrix3, Matrix4};
-use num::{BaseFloat, BaseNum};
+use num::{BaseNum, BaseReal};
 use point::{Point2, Point3};
 use rotation::*;
 use vector::{Vector2, Vector3};
@@ -71,7 +71,7 @@ pub struct Decomposed<V: VectorSpace, R> {
 
 impl<P: EuclideanSpace, R: Rotation<P>> Transform<P> for Decomposed<P::Diff, R>
 where
-    P::Scalar: BaseFloat,
+    P::Scalar: BaseReal,
     // FIXME: Investigate why this is needed!
     P::Diff: VectorSpace,
 {
@@ -141,7 +141,7 @@ where
 pub trait Transform2<S: BaseNum>: Transform<Point2<S>> + Into<Matrix3<S>> {}
 pub trait Transform3<S: BaseNum>: Transform<Point3<S>> + Into<Matrix4<S>> {}
 
-impl<S: BaseFloat, R: Rotation2<S>> From<Decomposed<Vector2<S>, R>> for Matrix3<S> {
+impl<S: BaseReal, R: Rotation2<S>> From<Decomposed<Vector2<S>, R>> for Matrix3<S> {
     fn from(dec: Decomposed<Vector2<S>, R>) -> Matrix3<S> {
         let m: Matrix2<_> = dec.rot.into();
         let mut m: Matrix3<_> = (&m * dec.scale).into();
@@ -150,7 +150,7 @@ impl<S: BaseFloat, R: Rotation2<S>> From<Decomposed<Vector2<S>, R>> for Matrix3<
     }
 }
 
-impl<S: BaseFloat, R: Rotation3<S>> From<Decomposed<Vector3<S>, R>> for Matrix4<S> {
+impl<S: BaseReal, R: Rotation3<S>> From<Decomposed<Vector3<S>, R>> for Matrix4<S> {
     fn from(dec: Decomposed<Vector3<S>, R>) -> Matrix4<S> {
         let m: Matrix3<_> = dec.rot.into();
         let mut m: Matrix4<_> = (&m * dec.scale).into();
@@ -159,11 +159,11 @@ impl<S: BaseFloat, R: Rotation3<S>> From<Decomposed<Vector3<S>, R>> for Matrix4<
     }
 }
 
-impl<S: BaseFloat, R: Rotation2<S>> Transform2<S> for Decomposed<Vector2<S>, R> {}
+impl<S: BaseReal, R: Rotation2<S>> Transform2<S> for Decomposed<Vector2<S>, R> {}
 
-impl<S: BaseFloat, R: Rotation3<S>> Transform3<S> for Decomposed<Vector3<S>, R> {}
+impl<S: BaseReal, R: Rotation3<S>> Transform3<S> for Decomposed<Vector3<S>, R> {}
 
-impl<S: VectorSpace, R, E: BaseFloat> approx::AbsDiffEq for Decomposed<S, R>
+impl<S: VectorSpace, R, E: BaseReal> approx::AbsDiffEq for Decomposed<S, R>
 where
     S: approx::AbsDiffEq<Epsilon = E>,
     S::Scalar: approx::AbsDiffEq<Epsilon = E>,
@@ -184,7 +184,7 @@ where
     }
 }
 
-impl<S: VectorSpace, R, E: BaseFloat> approx::RelativeEq for Decomposed<S, R>
+impl<S: VectorSpace, R, E: BaseReal> approx::RelativeEq for Decomposed<S, R>
 where
     S: approx::RelativeEq<Epsilon = E>,
     S::Scalar: approx::RelativeEq<Epsilon = E>,
@@ -203,7 +203,7 @@ where
     }
 }
 
-impl<S: VectorSpace, R, E: BaseFloat> approx::UlpsEq for Decomposed<S, R>
+impl<S: VectorSpace, R, E: BaseReal> approx::UlpsEq for Decomposed<S, R>
 where
     S: approx::UlpsEq<Epsilon = E>,
     S::Scalar: approx::UlpsEq<Epsilon = E>,
@@ -225,10 +225,10 @@ where
 #[cfg(feature = "serde")]
 #[doc(hidden)]
 mod serde_ser {
-    use structure::VectorSpace;
     use super::Decomposed;
-    use serde::{self, Serialize};
     use serde::ser::SerializeStruct;
+    use serde::{self, Serialize};
+    use structure::VectorSpace;
 
     impl<V, R> Serialize for Decomposed<V, R>
     where
@@ -252,11 +252,11 @@ mod serde_ser {
 #[cfg(feature = "serde")]
 #[doc(hidden)]
 mod serde_de {
-    use structure::VectorSpace;
     use super::Decomposed;
     use serde::{self, Deserialize};
-    use std::marker::PhantomData;
     use std::fmt;
+    use std::marker::PhantomData;
+    use structure::VectorSpace;
 
     enum DecomposedField {
         Scale,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -369,7 +369,7 @@ macro_rules! impl_vector_default {
             $VectorN::new($($field),+)
         }
 
-        impl<S: BaseReal> $VectorN<S> {
+        impl<S: BaseFloat> $VectorN<S> {
             /// True if all entries in the vector are finite
             pub fn is_finite(&self) -> bool {
                 $(self.$field.is_finite())&&+
@@ -422,7 +422,7 @@ macro_rules! impl_vector_default {
                 fold_array!(mul, { $(self.$field),+ })
             }
 
-            fn is_finite(&self) -> bool where S: BaseReal {
+            fn is_finite(&self) -> bool where S: BaseFloat {
                 $(self.$field.is_finite())&&+
             }
         }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use num_traits::{Bounded, NumCast};
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;
-use num_traits::{Bounded, NumCast};
 use std::fmt;
 use std::iter;
 use std::mem;
@@ -25,7 +25,7 @@ use structure::*;
 
 use angle::Rad;
 use approx;
-use num::{BaseFloat, BaseNum};
+use num::{BaseFloat, BaseNum, BaseReal};
 
 #[cfg(feature = "simd")]
 use simd::f32x4 as Simdf32x4;
@@ -133,7 +133,7 @@ macro_rules! impl_vector {
             }
         }
 
-        impl<S: BaseFloat> MetricSpace for $VectorN<S> {
+        impl<S: BaseReal> MetricSpace for $VectorN<S> {
             type Metric = S;
 
             #[inline]
@@ -207,7 +207,7 @@ macro_rules! impl_vector {
             fn neg(self) -> $VectorN<S> { $VectorN::new($(-self.$field),+) }
         }
 
-        impl<S: BaseFloat> approx::AbsDiffEq for $VectorN<S> {
+        impl<S: BaseReal> approx::AbsDiffEq for $VectorN<S> {
             type Epsilon = S::Epsilon;
 
             #[inline]
@@ -221,7 +221,7 @@ macro_rules! impl_vector {
             }
         }
 
-        impl<S: BaseFloat> approx::RelativeEq for $VectorN<S> {
+        impl<S: BaseReal> approx::RelativeEq for $VectorN<S> {
             #[inline]
             fn default_max_relative() -> S::Epsilon {
                 S::default_max_relative()
@@ -233,7 +233,7 @@ macro_rules! impl_vector {
             }
         }
 
-        impl<S: BaseFloat> approx::UlpsEq for $VectorN<S> {
+        impl<S: BaseReal> approx::UlpsEq for $VectorN<S> {
             #[inline]
             fn default_max_ulps() -> u32 {
                 S::default_max_ulps()
@@ -247,7 +247,7 @@ macro_rules! impl_vector {
 
         impl<S> Distribution<$VectorN<S>> for Standard
             where Standard: Distribution<S>,
-                S: BaseFloat {
+                S: BaseReal {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $VectorN<S> {
                 $VectorN { $($field: rng.gen()),+ }
@@ -369,7 +369,7 @@ macro_rules! impl_vector_default {
             $VectorN::new($($field),+)
         }
 
-        impl<S: BaseFloat> $VectorN<S> {
+        impl<S: BaseReal> $VectorN<S> {
             /// True if all entries in the vector are finite
             pub fn is_finite(&self) -> bool {
                 $(self.$field.is_finite())&&+
@@ -390,7 +390,7 @@ macro_rules! impl_vector_default {
             }
         }
 
-        impl<S: BaseFloat> MetricSpace for $VectorN<S> {
+        impl<S: BaseReal> MetricSpace for $VectorN<S> {
             type Metric = S;
 
             #[inline]
@@ -422,7 +422,7 @@ macro_rules! impl_vector_default {
                 fold_array!(mul, { $(self.$field),+ })
             }
 
-            fn is_finite(&self) -> bool where S: BaseFloat {
+            fn is_finite(&self) -> bool where S: BaseReal {
                 $(self.$field.is_finite())&&+
             }
         }
@@ -464,7 +464,7 @@ macro_rules! impl_vector_default {
             default fn neg(self) -> $VectorN<S> { $VectorN::new($(-self.$field),+) }
         }
 
-        impl<S: BaseFloat> approx::AbsDiffEq for $VectorN<S> {
+        impl<S: BaseReal> approx::AbsDiffEq for $VectorN<S> {
             type Epsilon = S::Epsilon;
 
             #[inline]
@@ -478,7 +478,7 @@ macro_rules! impl_vector_default {
             }
         }
 
-        impl<S: BaseFloat> approx::RelativeEq for $VectorN<S> {
+        impl<S: BaseReal> approx::RelativeEq for $VectorN<S> {
             #[inline]
             fn default_max_relative() -> S::Epsilon {
                 S::default_max_relative()
@@ -490,7 +490,7 @@ macro_rules! impl_vector_default {
             }
         }
 
-        impl<S: BaseFloat> approx::UlpsEq for $VectorN<S> {
+        impl<S: BaseReal> approx::UlpsEq for $VectorN<S> {
             #[inline]
             fn default_max_ulps() -> u32 {
                 S::default_max_ulps()
@@ -503,7 +503,7 @@ macro_rules! impl_vector_default {
         }
 
         impl<S> Distribution<$VectorN<S>> for Standard 
-            where S: BaseFloat,
+            where S: BaseReal,
                 Standard: Distribution<S>  {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $VectorN<S> {
@@ -780,19 +780,19 @@ impl<S: BaseNum> Vector4<S> {
 #[inline]
 pub fn dot<V: InnerSpace>(a: V, b: V) -> V::Scalar
 where
-    V::Scalar: BaseFloat,
+    V::Scalar: BaseReal,
 {
     V::dot(a, b)
 }
 
-impl<S: BaseFloat> InnerSpace for Vector1<S> {
+impl<S: BaseReal> InnerSpace for Vector1<S> {
     #[inline]
     fn dot(self, other: Vector1<S>) -> S {
         Vector1::mul_element_wise(self, other).sum()
     }
 }
 
-impl<S: BaseFloat> InnerSpace for Vector2<S> {
+impl<S: BaseReal> InnerSpace for Vector2<S> {
     #[inline]
     fn dot(self, other: Vector2<S>) -> S {
         Vector2::mul_element_wise(self, other).sum()
@@ -804,7 +804,7 @@ impl<S: BaseFloat> InnerSpace for Vector2<S> {
     }
 }
 
-impl<S: BaseFloat> InnerSpace for Vector3<S> {
+impl<S: BaseReal> InnerSpace for Vector3<S> {
     #[inline]
     fn dot(self, other: Vector3<S>) -> S {
         Vector3::mul_element_wise(self, other).sum()
@@ -816,7 +816,7 @@ impl<S: BaseFloat> InnerSpace for Vector3<S> {
     }
 }
 
-impl<S: BaseFloat> InnerSpace for Vector4<S> {
+impl<S: BaseReal> InnerSpace for Vector4<S> {
     #[inline]
     fn dot(self, other: Vector4<S>) -> S {
         Vector4::mul_element_wise(self, other).sum()


### PR DESCRIPTION
This adds a new trait `BaseReal` which corresponds to [`num_traits::real::Real`](https://docs.rs/num-traits/0.2.5/num_traits/real/trait.Real.html) and replaces most uses of `BaseFloat`. This allows using `cgmath` with types that have no infinity or NaN values, such as fixed point arithmetic. 

I'm not sure if this is a breaking change; `BaseReal` is implemented for `T: BaseFloat` so this should strictly relax the trait bounds. I checked a couple of dependencies and they compiled fine.