### PR TITLE
[breaking] Move lerp() from InnerSpace to VectorSpace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+ - Move `lerp()` from `InnerSpace` to `VectorSpace`
+
 ## [v0.16.1] - 2018-03-21
 
 ### Added

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -181,6 +181,13 @@ where
 {
     /// The associated scalar.
     type Scalar: BaseNum;
+
+    /// Returns the result of linearly interpolating the vector
+    /// towards `other` by the specified amount.
+    #[inline]
+    fn lerp(self, other: Self, amount: Self::Scalar) -> Self {
+        self + ((other - self) * amount)
+    }
 }
 
 /// A type with a distance function between values.
@@ -259,13 +266,6 @@ where
     #[inline]
     fn normalize_to(self, magnitude: Self::Scalar) -> Self {
         self * (magnitude / self.magnitude())
-    }
-
-    /// Returns the result of linearly interpolating the magnitude of the vector
-    /// towards the magnitude of `other` by the specified amount.
-    #[inline]
-    fn lerp(self, other: Self, amount: Self::Scalar) -> Self {
-        self + ((other - self) * amount)
     }
 
     /// Returns the


### PR DESCRIPTION
Because it does not require dot product.
Along the way, fix the comment.

Fixes #471.