### PR TITLE
Add short constructors for points, to match the ones for vectors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub use vector::{dot, Vector1, Vector2, Vector3, Vector4, vec1, vec2, vec3, vec4
 
 pub use angle::{Deg, Rad};
 pub use euler::Euler;
-pub use point::{Point1, Point2, Point3};
+pub use point::{Point1, Point2, Point3, point1, point2, point3};
 pub use rotation::*;
 pub use transform::*;
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -78,7 +78,7 @@ impl<S: BaseNum> Point3<S> {
 }
 
 macro_rules! impl_point {
-    ($PointN:ident { $($field:ident),+ }, $VectorN:ident, $n:expr) => {
+    ($PointN:ident { $($field:ident),+ }, $VectorN:ident, $n:expr, $constructor:ident) => {
         impl<S> $PointN<S> {
             /// Construct a new point, using the provided values.
             #[inline]
@@ -94,6 +94,12 @@ macro_rules! impl_point {
             {
                 $PointN { $($field: f(self.$field)),+ }
             }
+        }
+
+        /// The short constructor.
+        #[inline]
+        pub const fn $constructor<S>($($field: S),+) -> $PointN<S> {
+            $PointN::new($($field),+)
         }
 
         impl<S: BaseNum> Array for $PointN<S> {
@@ -323,9 +329,9 @@ macro_rules! impl_scalar_ops {
     };
 }
 
-impl_point!(Point1 { x }, Vector1, 1);
-impl_point!(Point2 { x, y }, Vector2, 2);
-impl_point!(Point3 { x, y, z }, Vector3, 3);
+impl_point!(Point1 { x }, Vector1, 1, point1);
+impl_point!(Point2 { x, y }, Vector2, 2, point2);
+impl_point!(Point3 { x, y, z }, Vector3, 3, point3);
 
 impl<S: Copy> Point1<S> {
     impl_swizzle_functions!(Point1, Point2, Point3, S, x);

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -365,7 +365,7 @@ macro_rules! impl_vector_default {
 
         /// The short constructor.
         #[inline]
-        pub fn $constructor<S>($($field: S),+) -> $VectorN<S> {
+        pub const fn $constructor<S>($($field: S),+) -> $VectorN<S> {
             $VectorN::new($($field),+)
         }
 

--- a/tests/point.rs
+++ b/tests/point.rs
@@ -17,7 +17,14 @@
 extern crate approx;
 extern crate cgmath;
 
-use cgmath::{Point1, Point2, Point3};
+use cgmath::*;
+
+#[test]
+fn test_constructor() {
+    assert_eq!(point1(1f32), Point1::new(1f32));
+    assert_eq!(point2(1f32, 2f32), Point2::new(1f32, 2f32));
+    assert_eq!(point3(1f64, 2f64, 3f64), Point3::new(1f64, 2f64, 3f64));
+}
 
 macro_rules! impl_test_mul {
     ($PointN:ident { $($field:ident),+ }, $s:expr, $v:expr) => (

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -23,6 +23,7 @@ use std::iter;
 
 #[test]
 fn test_constructor() {
+    assert_eq!(vec1(1f32), Vector1::new(1f32));
     assert_eq!(vec2(1f32, 2f32), Vector2::new(1f32, 2f32));
     assert_eq!(vec3(1f64, 2f64, 3f64), Vector3::new(1f64, 2f64, 3f64));
     assert_eq!(


### PR DESCRIPTION
In my code I find that I need to create points almost as often as vectors, so having short constructors is helpful.