### PR TITLE
Readme links update, let travis fail on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
       env: CARGO_FEATURES="simd"
     - rust: nightly
       env: CARGO_FEATURES="serde simd"
+  allow_failures:
+    - rust: nightly
 
 script:
   - cargo build --features "$CARGO_FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ license = "Apache-2.0"
 description = "A linear algebra and mathematics library for computer graphics."
 
 documentation = "https://docs.rs/cgmath"
-homepage = "https://github.com/brendanzab/cgmath"
-repository = "https://github.com/brendanzab/cgmath"
+homepage = "https://github.com/rustgd/cgmath"
+repository = "https://github.com/rustgd/cgmath"
 readme = "README.md"
 
 keywords = ["gamedev", "math", "matrix", "vector", "quaternion"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # cgmath-rs
 
-[![Build Status](https://travis-ci.org/brendanzab/cgmath.svg?branch=master)](https://travis-ci.org/brendanzab/cgmath)
+[![Build Status](https://travis-ci.org/rustgd/cgmath.svg?branch=master)](https://travis-ci.org/rustgd/cgmath)
 [![Documentation](https://docs.rs/cgmath/badge.svg)](https://docs.rs/cgmath)
 [![Version](https://img.shields.io/crates/v/cgmath.svg)](https://crates.io/crates/cgmath)
-[![License](https://img.shields.io/crates/l/cgmath.svg)](https://github.com/brendanzab/cgmath/blob/master/LICENSE)
+[![License](https://img.shields.io/crates/l/cgmath.svg)](https://github.com/rustgd/cgmath/blob/master/LICENSE)
 [![Downloads](https://img.shields.io/crates/d/cgmath.svg)](https://crates.io/crates/cgmath)
 [![Gitter](https://badges.gitter.im/brendanzab/cgmath.svg)](https://gitter.im/brendanzab/cgmath)
 


### PR DESCRIPTION
This is unfortunate, but it appears that we need to move to the new SIMD API in order to unblock it.