### PR TITLE
Add documentation for `<Quaternion as Rotation<Point3<S>>>::rotate_vector`

### DIFF
--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -729,6 +729,9 @@ impl<S: BaseFloat> Rotation<Point3<S>> for Quaternion<S> {
         Quaternion::from_sv(k + k_cos_theta, a.cross(b)).normalize()
     }
 
+    /// Evaluate the conjugation of `vec` by `self`.
+    ///
+    /// Note that `self` should be a unit quaternion (i.e. normalized) to represent a 3D rotation.
     #[inline]
     fn rotate_vector(&self, vec: Vector3<S>) -> Vector3<S> {
         self * vec


### PR DESCRIPTION
Clarifies that a quaternion should be normalized to be used as a rotation. Does not enforce or assert that the quaternion is normalized because valid rotations can be slightly off of the unit quaternion due to floating point error.

Fixes #479.