### PR TITLE
Make `rand` dependency optional (but enabled by default)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ matrix:
     - rust: nightly
 
 script:
-  - cargo build --no-default-features --features "$CARGO_FEATURES"
-  - cargo test --no-default-features --features "$CARGO_FEATURES"
+  - cargo build --features "$CARGO_FEATURES"
+  - cargo test --features "$CARGO_FEATURES"
   - |
     if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
-      cargo bench --features "$CARGO_FEATURES"
+      # The benchmark always needs the 'rand' feature
+      cargo bench --features "$CARGO_FEATURES rand"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache: cargo
 
 env:
   - CARGO_FEATURES=""
-  - CARGO_FEATURES="mint serde"
+  - CARGO_FEATURES="mint serde rand"
 
 matrix:
   include:
@@ -21,8 +21,8 @@ matrix:
     - rust: nightly
 
 script:
-  - cargo build --features "$CARGO_FEATURES"
-  - cargo test --features "$CARGO_FEATURES"
+  - cargo build --no-default-features --features "$CARGO_FEATURES"
+  - cargo test --no-default-features --features "$CARGO_FEATURES"
   - |
     if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
       cargo bench --features "$CARGO_FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ keywords = ["gamedev", "math", "matrix", "vector", "quaternion"]
 name = "cgmath"
 
 [features]
-default = ["rand"]
 unstable = []
 swizzle = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["gamedev", "math", "matrix", "vector", "quaternion"]
 name = "cgmath"
 
 [features]
+default = ["rand"]
 unstable = []
 swizzle = []
 
@@ -24,7 +25,7 @@ swizzle = []
 approx = "0.3"
 mint = { version = "0.5", optional = true }
 num-traits = "0.2"
-rand = "0.6"
+rand = { version = "0.6", optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 simd = { version = "0.2", optional = true }
 

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -20,9 +20,11 @@ use std::f64;
 use std::iter;
 use std::ops::*;
 
-use rand::Rng;
-use rand::distributions::{Distribution, Standard};
-use rand::distributions::uniform::SampleUniform;
+#[cfg(feature = "rand")]
+use rand::{
+    Rng,
+    distributions::{Distribution, Standard, uniform::SampleUniform},
+};
 use num_traits::{cast, Bounded};
 
 use structure::*;
@@ -209,6 +211,7 @@ macro_rules! impl_angle {
             }
         }
 
+        #[cfg(feature = "rand")]
         impl<S> Distribution<$Angle<S>> for Standard
             where Standard: Distribution<S>,
                 S: BaseFloat + SampleUniform {

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -13,8 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    Rng,
+    distributions::{Distribution, Standard},
+};
 use num_traits::cast;
 
 use structure::*;
@@ -186,6 +189,7 @@ impl<A: Angle> approx::UlpsEq for Euler<A> {
     }
 }
 
+#[cfg(feature = "rand")]
 impl<A> Distribution<Euler<A>> for Standard
     where Standard: Distribution<A>,
         A: Angle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ extern crate approx;
 #[cfg(feature = "mint")]
 pub extern crate mint;
 
+#[cfg(feature = "rand")]
 extern crate rand;
 pub extern crate num_traits;
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -13,8 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::distributions::{Standard, Distribution};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    Rng,
+    distributions::{Standard, Distribution},
+};
 use num_traits::{cast, NumCast};
 use std::fmt;
 use std::iter;
@@ -1536,8 +1539,9 @@ impl<S: fmt::Debug> fmt::Debug for Matrix4<S> {
     }
 }
 
+#[cfg(feature = "rand")]
 impl<S> Distribution<Matrix2<S>> for Standard
-    where 
+    where
         Standard: Distribution<Vector2<S>>,
         S: BaseFloat {
     #[inline]
@@ -1549,6 +1553,7 @@ impl<S> Distribution<Matrix2<S>> for Standard
     }
 }
 
+#[cfg(feature = "rand")]
 impl<S> Distribution<Matrix3<S>> for Standard
     where Standard: Distribution<Vector3<S>>,
         S: BaseFloat {
@@ -1562,6 +1567,7 @@ impl<S> Distribution<Matrix3<S>> for Standard
     }
 }
 
+#[cfg(feature = "rand")]
 impl<S> Distribution<Matrix4<S>> for Standard
     where Standard: Distribution<Vector4<S>>,
         S: BaseFloat {

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -17,8 +17,11 @@ use std::iter;
 use std::mem;
 use std::ops::*;
 
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    Rng,
+    distributions::{Distribution, Standard},
+};
 use num_traits::{cast, NumCast};
 
 use structure::*;
@@ -870,7 +873,8 @@ index_operators!(S, [S], RangeTo<usize>);
 index_operators!(S, [S], RangeFrom<usize>);
 index_operators!(S, [S], RangeFull);
 
-impl<S> Distribution<Quaternion<S>> for Standard 
+#[cfg(feature = "rand")]
+impl<S> Distribution<Quaternion<S>> for Standard
     where Standard: Distribution<S>,
         Standard: Distribution<Vector3<S>>,
         S: BaseFloat {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -13,8 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "rand")]
+use rand::{
+    Rng,
+    distributions::{Distribution, Standard},
+};
 use num_traits::{Bounded, NumCast};
 use std::fmt;
 use std::iter;
@@ -245,6 +248,7 @@ macro_rules! impl_vector {
             }
         }
 
+        #[cfg(feature = "rand")]
         impl<S> Distribution<$VectorN<S>> for Standard
             where Standard: Distribution<S>,
                 S: BaseFloat {
@@ -502,7 +506,8 @@ macro_rules! impl_vector_default {
             }
         }
 
-        impl<S> Distribution<$VectorN<S>> for Standard 
+        #[cfg(feature = "rand")]
+        impl<S> Distribution<$VectorN<S>> for Standard
             where S: BaseFloat,
                 Standard: Distribution<S>  {
             #[inline]


### PR DESCRIPTION
Closes #481 

This PR leaves the feature enabled by default so that this can be released as a minor version soon. (I would suggest to disable it by default in future versions, but that's another discussion.)

The changes are pretty straight forward with one catch: I changed some `use` statements to nested imports (otherwise, there would be even more `#[cfg(feature = "rand")]` lines). Nested imports were stabilized in 1.25 (see [the edition guide on this feature](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/nested-imports-with-use.html)). I'm not sure how cgmaths policy on minimum compiler version is. Maybe cgmath already requires a >= 1.25 compiler for other reasons. If my change is a problem, just tell me and I will change the imports back.