### PR TITLE
bump rand -> 0.7, fix unused macro warnings in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ swizzle = []
 approx = "0.3"
 mint = { version = "0.5", optional = true }
 num-traits = "0.2"
-rand = { version = "0.6", optional = true }
+rand = { version = "0.7", optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 simd = { version = "0.2", optional = true }
 

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate approx;
 extern crate cgmath;
 

--- a/tests/point.rs
+++ b/tests/point.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate approx;
 extern crate cgmath;
 

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate approx;
 extern crate cgmath;
 

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate approx;
 extern crate cgmath;
 

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate approx;
 extern crate cgmath;
 

--- a/tests/vector4f32.rs
+++ b/tests/vector4f32.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
 extern crate approx;
 extern crate cgmath;
 


### PR DESCRIPTION
Would it be possible to get a new release published? Rand is still a default feature in the published version.