### PR TITLE
Quaternion memory layout changed to `[x, y, z, w]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    default_fn! macro to reduce code duplication and complexity. Currently
    only needed for non-functional SIMD feature.
  - Refactored SIMD code into separate source files. See README.md for details.
+ - **Breaking**: Quaternion memory layout changed to `[x, y, z, w]`. The
+   `From` and `Into` impls for `[S; 4]` and `(S, S, S, S)` have been changed
+   accordingly.
+
 
 ### Added
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -46,10 +46,10 @@ use mint;
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Quaternion<S> {
-    /// The scalar part of the quaternion.
-    pub s: S,
     /// The vector part of the quaternion.
     pub v: Vector3<S>,
+    /// The scalar part of the quaternion.
+    pub s: S,
 }
 
 impl<S> Quaternion<S> {
@@ -530,7 +530,7 @@ impl<S: BaseFloat> Into<[S; 4]> for Quaternion<S> {
     #[inline]
     fn into(self) -> [S; 4] {
         match self.into() {
-            (w, xi, yj, zk) => [w, xi, yj, zk],
+            (xi, yj, zk, w) => [xi, yj, zk, w],
         }
     }
 }
@@ -552,7 +552,7 @@ impl<S: BaseFloat> AsMut<[S; 4]> for Quaternion<S> {
 impl<S: BaseFloat> From<[S; 4]> for Quaternion<S> {
     #[inline]
     fn from(v: [S; 4]) -> Quaternion<S> {
-        Quaternion::new(v[0], v[1], v[2], v[3])
+        Quaternion::new(v[3], v[0], v[1], v[2])
     }
 }
 
@@ -577,7 +577,7 @@ impl<S: BaseFloat> Into<(S, S, S, S)> for Quaternion<S> {
             Quaternion {
                 s,
                 v: Vector3 { x, y, z },
-            } => (s, x, y, z),
+            } => (x, y, z, s),
         }
     }
 }
@@ -600,7 +600,7 @@ impl<S: BaseFloat> From<(S, S, S, S)> for Quaternion<S> {
     #[inline]
     fn from(v: (S, S, S, S)) -> Quaternion<S> {
         match v {
-            (w, xi, yj, zk) => Quaternion::new(w, xi, yj, zk),
+            (xi, yj, zk, w) => Quaternion::new(w, xi, yj, zk),
         }
     }
 }
@@ -686,12 +686,12 @@ mod tests {
     use vector::*;
 
     const QUATERNION: Quaternion<f32> = Quaternion {
-        s: 1.0,
         v: Vector3 {
-            x: 2.0,
-            y: 3.0,
-            z: 4.0,
+            x: 1.0,
+            y: 2.0,
+            z: 3.0,
         },
+        s: 4.0,
     };
 
     #[test]


### PR DESCRIPTION
The `From` and `Into` impls for `[S; 4]` and `(S, S, S, S)` have been changed accordingly. This is consistent with other libraries like glm, nalgebra, and glam, as well as the glTF spec.

Note that the `Quaternion::new` constructor has not yet been updated.

Related: https://github.com/rustgd/cgmath/issues/499

@kvark I hadn't previously thought much about the From/Into conversions for `[S; 4]` and `(S, S, S, S)`. It makes me a little nervous since this change is going to break safe code. We should probably also update the `Quaternion::new` constructor but I wanted to see if there was any feedback first. 

