### PR TITLE
Relax BaseFloat bounds

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -17,7 +17,7 @@
 //! distinguishes them from vectors, which have a length and direction, but do
 //! not have a fixed position.
 
-use num_traits::{Bounded, NumCast};
+use num_traits::{Float, Bounded, NumCast};
 use std::fmt;
 use std::mem;
 use std::ops::*;
@@ -135,7 +135,7 @@ macro_rules! impl_point {
                 fold_array!(mul, { $(self.$field),+ })
             }
 
-            fn is_finite(&self) -> bool where S: BaseFloat {
+            fn is_finite(&self) -> bool where S: Float {
                 $(self.$field.is_finite())&&+
             }
         }

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -91,7 +91,7 @@ where
     /// Whether all elements of the array are finite
     fn is_finite(&self) -> bool
     where
-        Self::Element: BaseFloat;
+        Self::Element: Float;
 }
 
 /// Element-wise arithmetic operations. These are supplied for pragmatic

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -429,9 +429,6 @@ where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     Self: Index<usize, Output = <Self as Matrix>::Column>,
     Self: IndexMut<usize, Output = <Self as Matrix>::Column>,
-    //Self: approx::AbsDiffEq<Epsilon = <Self as VectorSpace>::Scalar>,
-    //Self: approx::RelativeEq<Epsilon = <Self as VectorSpace>::Scalar>,
-    //Self: approx::UlpsEq<Epsilon = <Self as VectorSpace>::Scalar>,
 {
     /// The row vector of the matrix.
     type Row: VectorSpace<Scalar = Self::Scalar> + Array<Element = Self::Scalar>;

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use num_traits::{Bounded, NumCast};
+use num_traits::{Float, Bounded, NumCast};
 #[cfg(feature = "rand")]
 use rand::{
     distributions::{Distribution, Standard},
@@ -139,7 +139,7 @@ macro_rules! impl_vector {
             }
         }
 
-        impl<S: BaseFloat> MetricSpace for $VectorN<S> {
+        impl<S: BaseNum + Float> MetricSpace for $VectorN<S> {
             type Metric = S;
 
             #[inline]
@@ -171,7 +171,7 @@ macro_rules! impl_vector {
                 fold_array!(mul, { $(self.$field),+ })
             }
 
-            fn is_finite(&self) -> bool where S: BaseFloat {
+            fn is_finite(&self) -> bool where S: Float {
                 $(self.$field.is_finite())&&+
             }
         }
@@ -525,38 +525,38 @@ where
     V::dot(a, b)
 }
 
-impl<S: BaseFloat> InnerSpace for Vector1<S> {
+impl<S: BaseNum + Float> InnerSpace for Vector1<S> {
     #[inline]
     fn dot(self, other: Vector1<S>) -> S {
         Vector1::mul_element_wise(self, other).sum()
     }
 }
 
-impl<S: BaseFloat> InnerSpace for Vector2<S> {
+impl<S: BaseNum + Float> InnerSpace for Vector2<S> {
     #[inline]
     fn dot(self, other: Vector2<S>) -> S {
         Vector2::mul_element_wise(self, other).sum()
     }
 
     #[inline]
-    fn angle(self, other: Vector2<S>) -> Rad<S> {
+    fn angle(self, other: Vector2<S>) -> Rad<S> where S: BaseFloat {
         Rad::atan2(Self::perp_dot(self, other), Self::dot(self, other))
     }
 }
 
-impl<S: BaseFloat> InnerSpace for Vector3<S> {
+impl<S: BaseNum + Float> InnerSpace for Vector3<S> {
     #[inline]
     fn dot(self, other: Vector3<S>) -> S {
         Vector3::mul_element_wise(self, other).sum()
     }
 
     #[inline]
-    fn angle(self, other: Vector3<S>) -> Rad<S> {
+    fn angle(self, other: Vector3<S>) -> Rad<S> where S: BaseFloat {
         Rad::atan2(self.cross(other).magnitude(), Self::dot(self, other))
     }
 }
 
-impl<S: BaseFloat> InnerSpace for Vector4<S> {
+impl<S: BaseNum + Float> InnerSpace for Vector4<S> {
     #[inline]
     fn dot(self, other: Vector4<S>) -> S {
         Vector4::mul_element_wise(self, other).sum()


### PR DESCRIPTION
This PR makes a step towards finer grained trait bounds (#496)

Here I just relaxed the `BaseFloat` trait bounds into `num_traits::Float` on `InnerSpace`, `MetricSpace` and `is_finite`, and added the required bounds from `approx` to the functions that need it.

This is helpful because it allows the use of common functions like `magnitude` without having to implement the `approx` traits on the number type.