### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ swizzle = []
 approx = "0.3"
 mint = { version = "0.5", optional = true }
 num-traits = "0.2"
-rand = { version = "0.7", optional = true }
+# small_rng used only for benchmarks
+rand = { version = "0.7", features = ["small_rng"], optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 simd = { version = "0.2", optional = true }  # works only in rust toolchain up to 1.32
 

--- a/benches/common/macros.rs
+++ b/benches/common/macros.rs
@@ -19,7 +19,7 @@ macro_rules! bench_binop {
         fn $name(bh: &mut Bencher) {
             const LEN: usize = 1 << 13;
 
-            let mut rng = IsaacRng::from_entropy();
+            let mut rng = SmallRng::from_entropy();
 
             let elems1: Vec<$t1> = (0..LEN).map(|_| rng.gen::<$t1>()).collect();
             let elems2: Vec<$t2> = (0..LEN).map(|_| rng.gen::<$t2>()).collect();
@@ -40,7 +40,7 @@ macro_rules! bench_unop {
         fn $name(bh: &mut Bencher) {
             const LEN: usize = 1 << 13;
 
-            let mut rng = IsaacRng::from_entropy();
+            let mut rng = SmallRng::from_entropy();
 
             let mut elems: Vec<$t> = (0..LEN).map(|_| rng.gen::<$t>()).collect();
             let mut i = 0;
@@ -60,7 +60,7 @@ macro_rules! bench_construction {
         fn $name(bh: &mut Bencher) {
             const LEN: usize = 1 << 13;
 
-            let mut rng = IsaacRng::from_entropy();
+            let mut rng = SmallRng::from_entropy();
 
             $(let $args: Vec<$types> = (0..LEN).map(|_| rng.gen::<$types>()).collect();)*
             let mut i = 0;

--- a/benches/construction.rs
+++ b/benches/construction.rs
@@ -20,9 +20,10 @@ extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use cgmath::*;
-use rand::{FromEntropy, IsaacRng, Rng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 use test::Bencher;
+
+use cgmath::*;
 
 #[path = "common/macros.rs"]
 #[macro_use]
@@ -31,7 +32,7 @@ mod macros;
 fn bench_from_axis_angle<T: Rotation3<f32>>(bh: &mut Bencher) {
     const LEN: usize = 1 << 13;
 
-    let mut rng = IsaacRng::from_entropy();
+    let mut rng = SmallRng::from_entropy();
 
     let axis: Vec<_> = (0..LEN).map(|_| rng.gen::<Vector3<f32>>()).collect();
     let angle: Vec<_> = (0..LEN).map(|_| rng.gen::<Rad<f32>>()).collect();

--- a/benches/mat.rs
+++ b/benches/mat.rs
@@ -20,7 +20,7 @@ extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{FromEntropy, IsaacRng, Rng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 use std::ops::*;
 use test::Bencher;
 

--- a/benches/quat.rs
+++ b/benches/quat.rs
@@ -14,12 +14,13 @@
 // limitations under the License.
 
 #![feature(test)]
+#![allow(unused_macros)]
 
 extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{FromEntropy, IsaacRng, Rng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 use std::ops::*;
 use test::Bencher;
 

--- a/benches/vec.rs
+++ b/benches/vec.rs
@@ -20,7 +20,7 @@ extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{FromEntropy, IsaacRng, Rng};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
 use std::ops::*;
 use test::Bencher;
 


### PR DESCRIPTION
This adds the `rand_isaac` dependency since that's no longer in the `rand` crate, but in the future we should consider switching to an RNG in `rand` so we don't need another dependency.