### PR TITLE
Add Transform::{look_at_rh, look_at_lh} and deprecate look_at

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -189,7 +189,7 @@ impl<S: BaseFloat> Matrix3<S> {
 
     /// Create a rotation matrix that will cause a vector to point at
     /// `dir`, using `up` for orientation.
-    #[deprecated = "Use Matrix3::look_at_lh"]
+    #[deprecated = "Use Matrix3::look_to_lh"]
     pub fn look_at(dir: Vector3<S>, up: Vector3<S>) -> Matrix3<S> {
         let dir = dir.normalize();
         let side = up.cross(dir).normalize();
@@ -200,7 +200,7 @@ impl<S: BaseFloat> Matrix3<S> {
 
     /// Create a rotation matrix that will cause a vector to point at
     /// `dir`, using `up` for orientation.
-    pub fn look_at_lh(dir: Vector3<S>, up: Vector3<S>) -> Matrix3<S> {
+    pub fn look_to_lh(dir: Vector3<S>, up: Vector3<S>) -> Matrix3<S> {
         let dir = dir.normalize();
         let side = up.cross(dir).normalize();
         let up = dir.cross(side).normalize();
@@ -210,12 +210,8 @@ impl<S: BaseFloat> Matrix3<S> {
 
     /// Create a rotation matrix that will cause a vector to point at
     /// `dir`, using `up` for orientation.
-    pub fn look_at_rh(dir: Vector3<S>, up: Vector3<S>) -> Matrix3<S> {
-        let dir = -dir.normalize();
-        let side = up.cross(dir).normalize();
-        let up = dir.cross(side).normalize();
-
-        Matrix3::from_cols(side, up, dir).transpose()
+    pub fn look_to_rh(dir: Vector3<S>, up: Vector3<S>) -> Matrix3<S> {
+        Matrix3::look_to_lh(-dir, up)
     }
 
     /// Create a rotation matrix from a rotation around the `x` axis (pitch).
@@ -1135,12 +1131,12 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix3<S> {
 
     fn look_at_lh(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Matrix3<S> {
         let dir = center - eye;
-        Matrix3::look_at_lh(dir, up)
+        Matrix3::look_to_lh(dir, up)
     }
 
     fn look_at_rh(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Matrix3<S> {
         let dir = center - eye;
-        Matrix3::look_at_rh(dir, up)
+        Matrix3::look_to_rh(dir, up)
     }
 
     fn transform_vector(&self, vec: Vector3<S>) -> Vector3<S> {

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -191,11 +191,7 @@ impl<S: BaseFloat> Matrix3<S> {
     /// `dir`, using `up` for orientation.
     #[deprecated = "Use Matrix3::look_to_lh"]
     pub fn look_at(dir: Vector3<S>, up: Vector3<S>) -> Matrix3<S> {
-        let dir = dir.normalize();
-        let side = up.cross(dir).normalize();
-        let up = dir.cross(side).normalize();
-
-        Matrix3::from_cols(side, up, dir).transpose()
+        Matrix3::look_to_lh(dir, up)
     }
 
     /// Create a rotation matrix that will cause a vector to point at

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -30,7 +30,16 @@ use std::ops::Mul;
 pub trait Transform<P: EuclideanSpace>: Sized + One {
     /// Create a transformation that rotates a vector to look at `center` from
     /// `eye`, using `up` for orientation.
+    #[deprecated = "Use look_at_rh or look_at_lh"]
     fn look_at(eye: P, center: P, up: P::Diff) -> Self;
+
+    /// Create a transformation that rotates a vector to look at `center` from
+    /// `eye`, using `up` for orientation.
+    fn look_at_rh(eye: P, center: P, up: P::Diff) -> Self;
+
+    /// Create a transformation that rotates a vector to look at `center` from
+    /// `eye`, using `up` for orientation.
+    fn look_at_lh(eye: P, center: P, up: P::Diff) -> Self;
 
     /// Transform a vector using this transform.
     fn transform_vector(&self, vec: P::Diff) -> P::Diff;
@@ -105,6 +114,28 @@ where
     #[inline]
     fn look_at(eye: P, center: P, up: P::Diff) -> Decomposed<P::Diff, R> {
         let rot = R::look_at(center - eye, up);
+        let disp = rot.rotate_vector(P::origin() - eye);
+        Decomposed {
+            scale: P::Scalar::one(),
+            rot: rot,
+            disp: disp,
+        }
+    }
+
+    #[inline]
+    fn look_at_lh(eye: P, center: P, up: P::Diff) -> Decomposed<P::Diff, R> {
+        let rot = R::look_at(center - eye, up);
+        let disp = rot.rotate_vector(P::origin() - eye);
+        Decomposed {
+            scale: P::Scalar::one(),
+            rot: rot,
+            disp: disp,
+        }
+    }
+
+    #[inline]
+    fn look_at_rh(eye: P, center: P, up: P::Diff) -> Decomposed<P::Diff, R> {
+        let rot = R::look_at(eye - center, up);
         let disp = rot.rotate_vector(P::origin() - eye);
         Decomposed {
             scale: P::Scalar::one(),

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -1127,6 +1127,48 @@ pub mod matrix4 {
         );
     }
 
+    #[test]
+    fn test_look_to_rh() {
+        let eye = Point3::new(10.0, 15.0, 20.0);
+        let dir = Vector3::new(1.0, 2.0, 3.0).normalize();
+        let up = Vector3::unit_y();
+
+        let m = Matrix4::look_to_rh(eye, dir, up);
+        #[allow(deprecated)]
+        assert_ulps_eq!(m, Matrix4::look_at_dir(eye, dir, up));
+
+        let expected = Matrix4::from([
+            [-0.9486833, -0.16903086, -0.26726127, 0.0],
+            [0.0, 0.84515435, -0.53452253, 0.0],
+            [0.31622776, -0.5070926, -0.8017838, 0.0],
+            [3.1622782, -0.84515476, 26.726126, 1.0_f32]
+        ]);
+        assert_ulps_eq!(expected, m);
+
+        let m = Matrix4::look_at_rh(eye, eye + dir, up);
+        assert_abs_diff_eq!(expected, m, epsilon = 1.0e-4);
+    }
+
+    #[test]
+    fn test_look_to_lh() {
+        let eye = Point3::new(10.0, 15.0, 20.0);
+        let dir = Vector3::new(1.0, 2.0, 3.0).normalize();
+        let up = Vector3::unit_y();
+
+        let m = Matrix4::look_to_lh(eye, dir, up);
+
+        let expected = Matrix4::from([
+            [0.9486833, -0.16903086, 0.26726127, 0.0],
+            [0.0, 0.84515435, 0.53452253, 0.0],
+            [-0.31622776, -0.5070926, 0.8017838, 0.0],
+            [-3.1622782, -0.84515476, -26.726126, 1.0_f32]
+        ]);
+        assert_ulps_eq!(expected, m);
+
+        let m = Matrix4::look_at_lh(eye, eye + dir, up);
+        assert_abs_diff_eq!(expected, m, epsilon = 1.0e-4);
+    }
+
     mod from {
         use cgmath::*;
 

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -726,6 +726,35 @@ pub mod matrix3 {
             );
         }
     }
+
+    #[test]
+    fn test_look_at_lh() {
+        let dir = Vector3::new(1.0, 2.0, 3.0).normalize();
+        let up = Vector3::unit_y();
+        let m = Matrix3::look_at_lh(dir, up);
+
+        assert_ulps_eq!(m, Matrix3::from([
+            [0.9486833, -0.16903085, 0.26726127],
+            [0.0, 0.8451542, 0.53452253],
+            [-0.31622776, -0.50709254, 0.8017838_f32]
+        ]));
+
+        #[allow(deprecated)]
+        assert_ulps_eq!(m, Matrix3::look_at(dir, up));
+    }
+
+    #[test]
+    fn test_look_at_rh() {
+        let dir = Vector3::new(1.0, 2.0, 3.0).normalize();
+        let up = Vector3::unit_y();
+        let m = Matrix3::look_at_rh(dir, up);
+
+        assert_ulps_eq!(m, Matrix3::from([
+            [-0.9486833, -0.16903085, -0.26726127],
+            [0.0, 0.8451542, -0.53452253],
+            [0.31622776, -0.50709254, -0.8017838_f32]
+        ]));
+    }
 }
 
 pub mod matrix4 {

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -728,10 +728,10 @@ pub mod matrix3 {
     }
 
     #[test]
-    fn test_look_at_lh() {
+    fn test_look_to_lh() {
         let dir = Vector3::new(1.0, 2.0, 3.0).normalize();
         let up = Vector3::unit_y();
-        let m = Matrix3::look_at_lh(dir, up);
+        let m = Matrix3::look_to_lh(dir, up);
 
         assert_ulps_eq!(m, Matrix3::from([
             [0.9486833, -0.16903085, 0.26726127],
@@ -744,10 +744,10 @@ pub mod matrix3 {
     }
 
     #[test]
-    fn test_look_at_rh() {
+    fn test_look_to_rh() {
         let dir = Vector3::new(1.0, 2.0, 3.0).normalize();
         let up = Vector3::unit_y();
-        let m = Matrix3::look_at_rh(dir, up);
+        let m = Matrix3::look_to_rh(dir, up);
 
         assert_ulps_eq!(m, Matrix3::from([
             [-0.9486833, -0.16903085, -0.26726127],

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -88,6 +88,7 @@ fn test_inverse_vector() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_look_at() {
     let eye = Point3::new(0.0f64, 0.0, -5.0);
     let center = Point3::new(0.0f64, 0.0, 0.0);
@@ -95,6 +96,42 @@ fn test_look_at() {
     let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at(eye, center, up);
     let point = Point3::new(1.0f64, 0.0, 0.0);
     let view_point = Point3::new(0.0f64, 1.0, 5.0);
+    assert_ulps_eq!(&t.transform_point(point), &view_point);
+}
+
+#[test]
+fn test_look_at_lh() {
+    let eye = Point3::new(0.0f64, 0.0, -5.0);
+    let center = Point3::new(0.0f64, 0.0, 0.0);
+    let up = Vector3::new(1.0f64, 0.0, 0.0);
+    let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at_lh(eye, center, up);
+    let point = Point3::new(1.0f64, 0.0, 0.0);
+    let view_point = Point3::new(0.0f64, 1.0, 5.0);
+    assert_ulps_eq!(&t.transform_point(point), &view_point);
+
+    // Decomposed::look_at_lh and Matrix4::look_at_lh should be consistent
+    let t: Matrix4<f64> = Transform::look_at_lh(eye, center, up);
+    assert_ulps_eq!(&t.transform_point(point), &view_point);
+
+    // Decomposed::look_at is inconsistent and deprecated, but verify that the behvaior
+    // remains the same until removed.
+    #[allow(deprecated)]
+    let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at(eye, center, up);
+    assert_ulps_eq!(&t.transform_point(point), &view_point);
+}
+
+#[test]
+fn test_look_at_rh() {
+    let eye = Point3::new(0.0f64, 0.0, -5.0);
+    let center = Point3::new(0.0f64, 0.0, 0.0);
+    let up = Vector3::new(1.0f64, 0.0, 0.0);
+    let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at_rh(eye, center, up);
+    let point = Point3::new(1.0f64, 0.0, 0.0);
+    let view_point = Point3::new(0.0f64, 1.0, -5.0);
+    assert_ulps_eq!(&t.transform_point(point), &view_point);
+
+    // Decomposed::look_at_rh and Matrix4::look_at_rh should be consistent
+    let t: Matrix4<f64> = Transform::look_at_rh(eye, center, up);
     assert_ulps_eq!(&t.transform_point(point), &view_point);
 }
 

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -94,6 +94,7 @@ fn test_look_at() {
     let center = Point3::new(0.0f64, 0.0, 0.0);
     let up = Vector3::new(1.0f64, 0.0, 0.0);
     let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at(eye, center, up);
+    assert_ulps_eq!(t, Decomposed::<Vector3<f64>, Quaternion<f64>>::look_at(eye, center, up));
     let point = Point3::new(1.0f64, 0.0, 0.0);
     let view_point = Point3::new(0.0f64, 1.0, 5.0);
     assert_ulps_eq!(&t.transform_point(point), &view_point);
@@ -105,12 +106,14 @@ fn test_look_at_lh() {
     let center = Point3::new(0.0f64, 0.0, 0.0);
     let up = Vector3::new(1.0f64, 0.0, 0.0);
     let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at_lh(eye, center, up);
+    assert_ulps_eq!(t, Decomposed::<Vector3<f64>, Quaternion<f64>>::look_at_lh(eye, center, up));
     let point = Point3::new(1.0f64, 0.0, 0.0);
     let view_point = Point3::new(0.0f64, 1.0, 5.0);
     assert_ulps_eq!(&t.transform_point(point), &view_point);
 
     // Decomposed::look_at_lh and Matrix4::look_at_lh should be consistent
     let t: Matrix4<f64> = Transform::look_at_lh(eye, center, up);
+    assert_ulps_eq!(t, Matrix4::<f64>::look_at_lh(eye, center, up));
     assert_ulps_eq!(&t.transform_point(point), &view_point);
 
     // Decomposed::look_at is inconsistent and deprecated, but verify that the behvaior
@@ -126,12 +129,14 @@ fn test_look_at_rh() {
     let center = Point3::new(0.0f64, 0.0, 0.0);
     let up = Vector3::new(1.0f64, 0.0, 0.0);
     let t: Decomposed<Vector3<f64>, Quaternion<f64>> = Transform::look_at_rh(eye, center, up);
+    assert_ulps_eq!(t, Decomposed::<Vector3<f64>, Quaternion<f64>>::look_at_rh(eye, center, up));
     let point = Point3::new(1.0f64, 0.0, 0.0);
     let view_point = Point3::new(0.0f64, 1.0, -5.0);
     assert_ulps_eq!(&t.transform_point(point), &view_point);
 
     // Decomposed::look_at_rh and Matrix4::look_at_rh should be consistent
     let t: Matrix4<f64> = Transform::look_at_rh(eye, center, up);
+    assert_ulps_eq!(t, Matrix4::<f64>::look_at_rh(eye, center, up));
     assert_ulps_eq!(&t.transform_point(point), &view_point);
 }
 


### PR DESCRIPTION
The corresponding functions have been added to Matrix4 and Decomposed and are now consistent.

Matrix3, Matrix2, and the Rotation trait are only partially updated. The `look_at` methods on these should probably be renamed to `look_to_[lh|rh]` as they take a direction vector, not a focus point. Does handedness even make sense for Matrix2?

The older functions have all been left in-tact and marked deprecated. I don't think the old functionality should be removed in the near or medium term.

