### PR TITLE
Allow inverted near far for inverted depth fp32

### DIFF
--- a/src/projection.rs
+++ b/src/projection.rs
@@ -117,8 +117,9 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
             "The vertical field of view cannot be greater than a half turn, found: {:?}",
             persp.fovy
         );
+
         assert!(
-            persp.aspect.abs() > S::zero(),
+            abs_diff_ne!(persp.aspect.abs(), S::zero()),
             "The absolute aspect ratio cannot be zero, found: {:?}",
             persp.aspect.abs()
         );
@@ -133,7 +134,7 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
             persp.far
         );
         assert!(
-            (persp.far - persp.near).abs() > S::epsilon(),
+            abs_diff_ne!((persp.far - persp.near).abs() ,S::zero()),
             "The far plane and near plane are too close, found: far: {:?}, near: {:?}",
             persp.far,
             persp.near

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -118,6 +118,11 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
             persp.fovy
         );
         assert!(
+            persp.aspect.abs() > S::zero(),
+            "The absolute aspect ratio cannot be zero, found: {:?}",
+            persp.aspect.abs()
+        );
+        assert!(
             persp.near > S::zero(),
             "The near plane distance cannot be below zero, found: {:?}",
             persp.near
@@ -126,6 +131,12 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
             persp.far > S::zero(),
             "The far plane distance cannot be below zero, found: {:?}",
             persp.far
+        );
+        assert!(
+            (persp.far - persp.near).abs() > S::epsilon(),
+            "The far plane and near plane are too close, found: far: {:?}, near: {:?}",
+            persp.far,
+            persp.near
         );
 
         let two: S = cast(2).unwrap();

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -127,12 +127,6 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
             "The far plane distance cannot be below zero, found: {:?}",
             persp.far
         );
-        assert!(
-            persp.far > persp.near,
-            "The far plane cannot be closer than the near plane, found: far: {:?}, near: {:?}",
-            persp.far,
-            persp.near
-        );
 
         let two: S = cast(2).unwrap();
         let f = Rad::cot(persp.fovy / two);

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -118,11 +118,6 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
             persp.fovy
         );
         assert!(
-            persp.aspect > S::zero(),
-            "The aspect ratio cannot be below zero, found: {:?}",
-            persp.aspect
-        );
-        assert!(
             persp.near > S::zero(),
             "The near plane distance cannot be below zero, found: {:?}",
             persp.near

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -134,7 +134,7 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
             persp.far
         );
         assert!(
-            abs_diff_ne!((persp.far - persp.near).abs() ,S::zero()),
+            abs_diff_ne!(persp.far, persp.near),
             "The far plane and near plane are too close, found: far: {:?}, near: {:?}",
             persp.far,
             persp.near


### PR DESCRIPTION
While trying to make an inverted depth using a floating-point depth buffer. I got a panic from the asserts! macro preventing such behaviour. 

I have removed such macros to allow for a higher accuracy inverted depth fp32 buffer. 
Here below a render doc screenshot of it working:
![image](https://user-images.githubusercontent.com/2525797/85414799-799e5c80-b564-11ea-8def-684ead28d486.png)

Tests still pass accordingly. 

I did not find any particular guideline on the contribution or how the PR should be formatted, so I hope this is good enough. 

