### PR TITLE
Now there is only one one

### DIFF
--- a/benches/construction.rs
+++ b/benches/construction.rs
@@ -20,7 +20,7 @@ extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use test::Bencher;
 
 use cgmath::*;

--- a/benches/mat.rs
+++ b/benches/mat.rs
@@ -20,7 +20,7 @@ extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::ops::*;
 use test::Bencher;
 

--- a/benches/quat.rs
+++ b/benches/quat.rs
@@ -20,7 +20,7 @@ extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::ops::*;
 use test::Bencher;
 

--- a/benches/vec.rs
+++ b/benches/vec.rs
@@ -20,7 +20,7 @@ extern crate cgmath;
 extern crate rand;
 extern crate test;
 
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::ops::*;
 use test::Bencher;
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1105,11 +1105,17 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> Transform2<S> for Matrix3<S> {}
+impl<S: BaseFloat> Transform2 for Matrix3<S> {
+    type Scalar = S;
+}
 
-impl<S: BaseFloat> Transform3<S> for Matrix3<S> {}
+impl<S: BaseFloat> Transform3 for Matrix3<S> {
+    type Scalar = S;
+}
 
-impl<S: BaseFloat> Transform3<S> for Matrix4<S> {}
+impl<S: BaseFloat> Transform3 for Matrix4<S> {
+    type Scalar = S;
+}
 
 macro_rules! impl_matrix {
     ($MatrixN:ident, $VectorN:ident { $($field:ident : $row_index:expr),+ }) => {

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1038,10 +1038,6 @@ impl<S: BaseFloat> approx::UlpsEq for Matrix4<S> {
 }
 
 impl<S: BaseFloat> Transform<Point2<S>> for Matrix3<S> {
-    fn one() -> Matrix3<S> {
-        One::one()
-    }
-
     fn look_at(eye: Point2<S>, center: Point2<S>, up: Vector2<S>) -> Matrix3<S> {
         let dir = center - eye;
         Matrix3::from(Matrix2::look_at(dir, up))
@@ -1065,10 +1061,6 @@ impl<S: BaseFloat> Transform<Point2<S>> for Matrix3<S> {
 }
 
 impl<S: BaseFloat> Transform<Point3<S>> for Matrix3<S> {
-    fn one() -> Matrix3<S> {
-        One::one()
-    }
-
     fn look_at(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Matrix3<S> {
         let dir = center - eye;
         Matrix3::look_at(dir, up)
@@ -1092,10 +1084,6 @@ impl<S: BaseFloat> Transform<Point3<S>> for Matrix3<S> {
 }
 
 impl<S: BaseFloat> Transform<Point3<S>> for Matrix4<S> {
-    fn one() -> Matrix4<S> {
-        One::one()
-    }
-
     fn look_at(eye: Point3<S>, center: Point3<S>, up: Vector3<S>) -> Matrix4<S> {
         Matrix4::look_at(eye, center, up)
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -17,7 +17,7 @@
 //! distinguishes them from vectors, which have a length and direction, but do
 //! not have a fixed position.
 
-use num_traits::{Float, Bounded, NumCast};
+use num_traits::{Bounded, Float, NumCast};
 use std::fmt;
 use std::mem;
 use std::ops::*;

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -520,7 +520,9 @@ impl<S: BaseFloat> Rotation for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> Rotation3<S> for Quaternion<S> {
+impl<S: BaseFloat> Rotation3 for Quaternion<S> {
+    type Scalar = S;
+
     #[inline]
     fn from_axis_angle<A: Into<Rad<S>>>(axis: Vector3<S>, angle: A) -> Quaternion<S> {
         let (s, c) = Rad::sin_cos(angle.into() * cast(0.5f64).unwrap());

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -32,7 +32,7 @@ use euler::Euler;
 use matrix::{Matrix3, Matrix4};
 use num::BaseFloat;
 use point::Point3;
-use rotation::{Basis3, Rotation, Rotation3};
+use rotation::{Basis3, EuclideanRotation, Rotation, Rotation3};
 use vector::Vector3;
 
 #[cfg(feature = "mint")]
@@ -470,6 +470,10 @@ impl<S: BaseFloat> From<Quaternion<S>> for Basis3<S> {
     fn from(quat: Quaternion<S>) -> Basis3<S> {
         Basis3::from_quaternion(&quat)
     }
+}
+
+impl<S: BaseFloat> EuclideanRotation for Quaternion<S> {
+    type Euclidean = Point3<S>;
 }
 
 impl<S: BaseFloat> Rotation<Point3<S>> for Quaternion<S> {

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -32,7 +32,7 @@ use euler::Euler;
 use matrix::{Matrix3, Matrix4};
 use num::BaseFloat;
 use point::Point3;
-use rotation::{Basis3, EuclideanRotation, Rotation, Rotation3};
+use rotation::{Basis3, Rotation, Rotation3};
 use vector::Vector3;
 
 #[cfg(feature = "mint")]
@@ -472,11 +472,9 @@ impl<S: BaseFloat> From<Quaternion<S>> for Basis3<S> {
     }
 }
 
-impl<S: BaseFloat> EuclideanRotation for Quaternion<S> {
-    type Euclidean = Point3<S>;
-}
+impl<S: BaseFloat> Rotation for Quaternion<S> {
+    type Space = Point3<S>;
 
-impl<S: BaseFloat> Rotation<Point3<S>> for Quaternion<S> {
     #[inline]
     fn look_at(dir: Vector3<S>, up: Vector3<S>) -> Quaternion<S> {
         Matrix3::look_at(dir, up).into()

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -61,6 +61,19 @@ where
     fn invert(&self) -> Self;
 }
 
+/// A trait for a rotation in a specific Euclidean space.
+/// Implement this trait for any type that implements `Rotation<P>`
+/// for exactly one `P`,
+/// setting `type Euclidean = P`.
+/// In particular, a rotation cannot be used in `Decomposed`
+/// unless it implements `EuclideanRotation`.
+pub trait EuclideanRotation: Rotation<<Self as EuclideanRotation>::Euclidean>
+where
+    <<Self as EuclideanRotation>::Euclidean as EuclideanSpace>::Scalar: BaseFloat,
+{
+    type Euclidean: EuclideanSpace;
+}
+
 /// A two-dimensional rotation.
 pub trait Rotation2<S: BaseFloat>:
     Rotation<Point2<S>> + Into<Matrix2<S>> + Into<Basis2<S>>
@@ -181,6 +194,10 @@ impl<'a, S: 'a + BaseFloat> iter::Product<&'a Basis2<S>> for Basis2<S> {
     fn product<I: Iterator<Item = &'a Basis2<S>>>(iter: I) -> Basis2<S> {
         iter.fold(Basis2::one(), Mul::mul)
     }
+}
+
+impl<S: BaseFloat> EuclideanRotation for Basis2<S> {
+    type Euclidean = Point2<S>;
 }
 
 impl<S: BaseFloat> Rotation<Point2<S>> for Basis2<S> {
@@ -332,6 +349,10 @@ impl<'a, S: 'a + BaseFloat> iter::Product<&'a Basis3<S>> for Basis3<S> {
     fn product<I: Iterator<Item = &'a Basis3<S>>>(iter: I) -> Basis3<S> {
         iter.fold(Basis3::one(), Mul::mul)
     }
+}
+
+impl<S: BaseFloat> EuclideanRotation for Basis3<S> {
+    type Euclidean = Point3<S>;
 }
 
 impl<S: BaseFloat> Rotation<Point3<S>> for Basis3<S> {

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -42,14 +42,23 @@ where
     type Space: EuclideanSpace;
 
     /// Create a rotation to a given direction with an 'up' vector.
-    fn look_at(dir: <Self::Space as EuclideanSpace>::Diff, up: <Self::Space as EuclideanSpace>::Diff) -> Self;
+    fn look_at(
+        dir: <Self::Space as EuclideanSpace>::Diff,
+        up: <Self::Space as EuclideanSpace>::Diff,
+    ) -> Self;
 
     /// Create a shortest rotation to transform vector 'a' into 'b'.
     /// Both given vectors are assumed to have unit length.
-    fn between_vectors(a: <Self::Space as EuclideanSpace>::Diff, b: <Self::Space as EuclideanSpace>::Diff) -> Self;
+    fn between_vectors(
+        a: <Self::Space as EuclideanSpace>::Diff,
+        b: <Self::Space as EuclideanSpace>::Diff,
+    ) -> Self;
 
     /// Rotate a vector using this rotation.
-    fn rotate_vector(&self, vec: <Self::Space as EuclideanSpace>::Diff) -> <Self::Space as EuclideanSpace>::Diff;
+    fn rotate_vector(
+        &self,
+        vec: <Self::Space as EuclideanSpace>::Diff,
+    ) -> <Self::Space as EuclideanSpace>::Diff;
 
     /// Rotate a point using this rotation, by converting it to its
     /// representation as a vector.
@@ -64,38 +73,48 @@ where
 }
 
 /// A two-dimensional rotation.
-pub trait Rotation2<S: BaseFloat>:
-    Rotation<Space=Point2<S>> + Into<Matrix2<S>> + Into<Basis2<S>>
+pub trait Rotation2:
+    Rotation<Space = Point2<<Self as Rotation2>::Scalar>>
+    + Into<Matrix2<<Self as Rotation2>::Scalar>>
+    + Into<Basis2<<Self as Rotation2>::Scalar>>
 {
+    type Scalar: BaseFloat;
+
     /// Create a rotation by a given angle. Thus is a redundant case of both
     /// from_axis_angle() and from_euler() for 2D space.
-    fn from_angle<A: Into<Rad<S>>>(theta: A) -> Self;
+    fn from_angle<A: Into<Rad<Self::Scalar>>>(theta: A) -> Self;
 }
 
 /// A three-dimensional rotation.
-pub trait Rotation3<S: BaseFloat>:
-    Rotation<Space=Point3<S>> + Into<Matrix3<S>> + Into<Basis3<S>> + Into<Quaternion<S>> + From<Euler<Rad<S>>>
+pub trait Rotation3:
+    Rotation<Space = Point3<<Self as Rotation3>::Scalar>>
+    + Into<Matrix3<<Self as Rotation3>::Scalar>>
+    + Into<Basis3<<Self as Rotation3>::Scalar>>
+    + Into<Quaternion<<Self as Rotation3>::Scalar>>
+    + From<Euler<Rad<<Self as Rotation3>::Scalar>>>
 {
+    type Scalar: BaseFloat;
+
     /// Create a rotation using an angle around a given axis.
     ///
     /// The specified axis **must be normalized**, or it represents an invalid rotation.
-    fn from_axis_angle<A: Into<Rad<S>>>(axis: Vector3<S>, angle: A) -> Self;
+    fn from_axis_angle<A: Into<Rad<Self::Scalar>>>(axis: Vector3<Self::Scalar>, angle: A) -> Self;
 
     /// Create a rotation from an angle around the `x` axis (pitch).
     #[inline]
-    fn from_angle_x<A: Into<Rad<S>>>(theta: A) -> Self {
+    fn from_angle_x<A: Into<Rad<Self::Scalar>>>(theta: A) -> Self {
         Rotation3::from_axis_angle(Vector3::unit_x(), theta)
     }
 
     /// Create a rotation from an angle around the `y` axis (yaw).
     #[inline]
-    fn from_angle_y<A: Into<Rad<S>>>(theta: A) -> Self {
+    fn from_angle_y<A: Into<Rad<Self::Scalar>>>(theta: A) -> Self {
         Rotation3::from_axis_angle(Vector3::unit_y(), theta)
     }
 
     /// Create a rotation from an angle around the `z` axis (roll).
     #[inline]
-    fn from_angle_z<A: Into<Rad<S>>>(theta: A) -> Self {
+    fn from_angle_z<A: Into<Rad<Self::Scalar>>>(theta: A) -> Self {
         Rotation3::from_axis_angle(Vector3::unit_z(), theta)
     }
 }
@@ -266,7 +285,9 @@ impl<S: BaseFloat> approx::UlpsEq for Basis2<S> {
     }
 }
 
-impl<S: BaseFloat> Rotation2<S> for Basis2<S> {
+impl<S: BaseFloat> Rotation2 for Basis2<S> {
+    type Scalar = S;
+
     fn from_angle<A: Into<Rad<S>>>(theta: A) -> Basis2<S> {
         Basis2 {
             mat: Matrix2::from_angle(theta),
@@ -420,7 +441,9 @@ impl<S: BaseFloat> approx::UlpsEq for Basis3<S> {
     }
 }
 
-impl<S: BaseFloat> Rotation3<S> for Basis3<S> {
+impl<S: BaseFloat> Rotation3 for Basis3<S> {
+    type Scalar = S;
+
     fn from_axis_angle<A: Into<Rad<S>>>(axis: Vector3<S>, angle: A) -> Basis3<S> {
         Basis3 {
             mat: Matrix3::from_axis_angle(axis, angle),

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -36,7 +36,7 @@ where
     Self: approx::AbsDiffEq<Epsilon = <<Self as Rotation>::Space as EuclideanSpace>::Scalar>,
     Self: approx::RelativeEq<Epsilon = <<Self as Rotation>::Space as EuclideanSpace>::Scalar>,
     Self: approx::UlpsEq<Epsilon = <<Self as Rotation>::Space as EuclideanSpace>::Scalar>,
-    <<Self as Rotation>::Space as EuclideanSpace>::Scalar: BaseFloat,
+    <Self::Space as EuclideanSpace>::Scalar: BaseFloat,
     Self: iter::Product<Self>,
 {
     type Space: EuclideanSpace;

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -205,7 +205,10 @@ pub trait MetricSpace: Sized {
     fn distance2(self, other: Self) -> Self::Metric;
 
     /// The distance between two values.
-    fn distance(self, other: Self) -> Self::Metric where Self::Metric: Float {
+    fn distance(self, other: Self) -> Self::Metric
+    where
+        Self::Metric: Float,
+    {
         Float::sqrt(Self::distance2(self, other))
     }
 }
@@ -220,14 +223,17 @@ pub trait MetricSpace: Sized {
 pub trait InnerSpace: VectorSpace
 where
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
-    Self: MetricSpace<Metric = <Self as VectorSpace>::Scalar>
+    Self: MetricSpace<Metric = <Self as VectorSpace>::Scalar>,
 {
     /// Vector dot (or inner) product.
     fn dot(self, other: Self) -> Self::Scalar;
 
     /// Returns `true` if the vector is perpendicular (at right angles) to the
     /// other vector.
-    fn is_perpendicular(self, other: Self) -> bool where Self::Scalar: approx::UlpsEq {
+    fn is_perpendicular(self, other: Self) -> bool
+    where
+        Self::Scalar: approx::UlpsEq,
+    {
         ulps_eq!(Self::dot(self, other), &Self::Scalar::zero())
     }
 
@@ -242,7 +248,10 @@ where
     }
 
     /// Returns the angle between two vectors in radians.
-    fn angle(self, other: Self) -> Rad<Self::Scalar> where Self::Scalar: BaseFloat {
+    fn angle(self, other: Self) -> Rad<Self::Scalar>
+    where
+        Self::Scalar: BaseFloat,
+    {
         Rad::acos(Self::dot(self, other) / (self.magnitude() * other.magnitude()))
     }
 
@@ -256,19 +265,28 @@ where
 
     /// The distance from the tail to the tip of the vector.
     #[inline]
-    fn magnitude(self) -> Self::Scalar where Self::Scalar: Float {
+    fn magnitude(self) -> Self::Scalar
+    where
+        Self::Scalar: Float,
+    {
         Float::sqrt(self.magnitude2())
     }
 
     /// Returns a vector with the same direction, but with a magnitude of `1`.
     #[inline]
-    fn normalize(self) -> Self where Self::Scalar: Float {
+    fn normalize(self) -> Self
+    where
+        Self::Scalar: Float,
+    {
         self.normalize_to(Self::Scalar::one())
     }
 
     /// Returns a vector with the same direction and a given magnitude.
     #[inline]
-    fn normalize_to(self, magnitude: Self::Scalar) -> Self where Self::Scalar: Float {
+    fn normalize_to(self, magnitude: Self::Scalar) -> Self
+    where
+        Self::Scalar: Float,
+    {
         self * (magnitude / self.magnitude())
     }
 }
@@ -536,14 +554,20 @@ where
 
     /// Test if this matrix is invertible.
     #[inline]
-    fn is_invertible(&self) -> bool where Self::Scalar: approx::UlpsEq {
+    fn is_invertible(&self) -> bool
+    where
+        Self::Scalar: approx::UlpsEq,
+    {
         ulps_ne!(self.determinant(), &Self::Scalar::zero())
     }
 
     /// Test if this matrix is the identity matrix. That is, it is diagonal
     /// and every element in the diagonal is one.
     #[inline]
-    fn is_identity(&self) -> bool where Self: approx::UlpsEq {
+    fn is_identity(&self) -> bool
+    where
+        Self: approx::UlpsEq,
+    {
         ulps_eq!(self, &Self::identity())
     }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -105,7 +105,7 @@ where
 impl<P: EuclideanSpace, R: Rotation<Space = P>> Transform<P> for Decomposed<P::Diff, R>
 where
     P::Scalar: BaseFloat,
-    // FIXME: Investigate why this is needed!
+    // Needed to be able to multiply by a scalar
     P::Diff: VectorSpace,
 {
     #[inline]
@@ -165,12 +165,12 @@ where
 pub trait Transform2:
     Transform<Point2<<Self as Transform2>::Scalar>> + Into<Matrix3<<Self as Transform2>::Scalar>>
 {
-    type Scalar: BaseFloat;
+    type Scalar: BaseNum;
 }
 pub trait Transform3:
     Transform<Point3<<Self as Transform3>::Scalar>> + Into<Matrix4<<Self as Transform3>::Scalar>>
 {
-    type Scalar: BaseFloat;
+    type Scalar: BaseNum;
 }
 
 impl<S: BaseFloat, R: Rotation2<Scalar = S>> From<Decomposed<Vector2<S>, R>> for Matrix3<S> {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -67,7 +67,7 @@ pub struct Decomposed<V: VectorSpace, R> {
     pub disp: V,
 }
 
-impl<P: EuclideanSpace, R: Rotation<Space=P>> One for Decomposed<P::Diff, R>
+impl<P: EuclideanSpace, R: Rotation<Space = P>> One for Decomposed<P::Diff, R>
 where
     P::Scalar: BaseFloat,
     P::Diff: VectorSpace,
@@ -81,7 +81,7 @@ where
     }
 }
 
-impl<P: EuclideanSpace, R: Rotation<Space=P>> Mul for Decomposed<P::Diff, R>
+impl<P: EuclideanSpace, R: Rotation<Space = P>> Mul for Decomposed<P::Diff, R>
 where
     P::Scalar: BaseFloat,
     P::Diff: VectorSpace,
@@ -102,7 +102,7 @@ where
     }
 }
 
-impl<P: EuclideanSpace, R: Rotation<Space=P>> Transform<P> for Decomposed<P::Diff, R>
+impl<P: EuclideanSpace, R: Rotation<Space = P>> Transform<P> for Decomposed<P::Diff, R>
 where
     P::Scalar: BaseFloat,
     // FIXME: Investigate why this is needed!
@@ -162,10 +162,18 @@ where
     }
 }
 
-pub trait Transform2<S: BaseNum>: Transform<Point2<S>> + Into<Matrix3<S>> {}
-pub trait Transform3<S: BaseNum>: Transform<Point3<S>> + Into<Matrix4<S>> {}
+pub trait Transform2:
+    Transform<Point2<<Self as Transform2>::Scalar>> + Into<Matrix3<<Self as Transform2>::Scalar>>
+{
+    type Scalar: BaseFloat;
+}
+pub trait Transform3:
+    Transform<Point3<<Self as Transform3>::Scalar>> + Into<Matrix4<<Self as Transform3>::Scalar>>
+{
+    type Scalar: BaseFloat;
+}
 
-impl<S: BaseFloat, R: Rotation2<S>> From<Decomposed<Vector2<S>, R>> for Matrix3<S> {
+impl<S: BaseFloat, R: Rotation2<Scalar = S>> From<Decomposed<Vector2<S>, R>> for Matrix3<S> {
     fn from(dec: Decomposed<Vector2<S>, R>) -> Matrix3<S> {
         let m: Matrix2<_> = dec.rot.into();
         let mut m: Matrix3<_> = (&m * dec.scale).into();
@@ -174,7 +182,7 @@ impl<S: BaseFloat, R: Rotation2<S>> From<Decomposed<Vector2<S>, R>> for Matrix3<
     }
 }
 
-impl<S: BaseFloat, R: Rotation3<S>> From<Decomposed<Vector3<S>, R>> for Matrix4<S> {
+impl<S: BaseFloat, R: Rotation3<Scalar = S>> From<Decomposed<Vector3<S>, R>> for Matrix4<S> {
     fn from(dec: Decomposed<Vector3<S>, R>) -> Matrix4<S> {
         let m: Matrix3<_> = dec.rot.into();
         let mut m: Matrix4<_> = (&m * dec.scale).into();
@@ -183,9 +191,13 @@ impl<S: BaseFloat, R: Rotation3<S>> From<Decomposed<Vector3<S>, R>> for Matrix4<
     }
 }
 
-impl<S: BaseFloat, R: Rotation2<S>> Transform2<S> for Decomposed<Vector2<S>, R> {}
+impl<S: BaseFloat, R: Rotation2<Scalar = S>> Transform2 for Decomposed<Vector2<S>, R> {
+    type Scalar = S;
+}
 
-impl<S: BaseFloat, R: Rotation3<S>> Transform3<S> for Decomposed<Vector3<S>, R> {}
+impl<S: BaseFloat, R: Rotation3<Scalar = S>> Transform3 for Decomposed<Vector3<S>, R> {
+    type Scalar = S;
+}
 
 impl<S: VectorSpace, R, E: BaseFloat> approx::AbsDiffEq for Decomposed<S, R>
 where

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -67,10 +67,7 @@ pub struct Decomposed<V: VectorSpace, R> {
     pub disp: V,
 }
 
-// using `EuclideanRotation` here to avoid the possibility that
-// the same struct implements `Rotation<P1>` and `Rotation<P2>`
-// and the compiler has to guess what `P` is.
-impl<P: EuclideanSpace, R: EuclideanRotation<Euclidean = P>> One for Decomposed<P::Diff, R>
+impl<P: EuclideanSpace, R: Rotation<Space=P>> One for Decomposed<P::Diff, R>
 where
     P::Scalar: BaseFloat,
     P::Diff: VectorSpace,
@@ -84,7 +81,7 @@ where
     }
 }
 
-impl<P: EuclideanSpace, R: EuclideanRotation<Euclidean = P>> Mul for Decomposed<P::Diff, R>
+impl<P: EuclideanSpace, R: Rotation<Space=P>> Mul for Decomposed<P::Diff, R>
 where
     P::Scalar: BaseFloat,
     P::Diff: VectorSpace,
@@ -105,7 +102,7 @@ where
     }
 }
 
-impl<P: EuclideanSpace, R: EuclideanRotation<Euclidean = P>> Transform<P> for Decomposed<P::Diff, R>
+impl<P: EuclideanSpace, R: Rotation<Space=P>> Transform<P> for Decomposed<P::Diff, R>
 where
     P::Scalar: BaseFloat,
     // FIXME: Investigate why this is needed!
@@ -186,15 +183,9 @@ impl<S: BaseFloat, R: Rotation3<S>> From<Decomposed<Vector3<S>, R>> for Matrix4<
     }
 }
 
-impl<S: BaseFloat, R> Transform2<S> for Decomposed<Vector2<S>, R> where
-    R: Rotation2<S> + EuclideanRotation<Euclidean = Point2<S>>
-{
-}
+impl<S: BaseFloat, R: Rotation2<S>> Transform2<S> for Decomposed<Vector2<S>, R> {}
 
-impl<S: BaseFloat, R> Transform3<S> for Decomposed<Vector3<S>, R> where
-    R: Rotation3<S> + EuclideanRotation<Euclidean = Point3<S>>
-{
-}
+impl<S: BaseFloat, R: Rotation3<S>> Transform3<S> for Decomposed<Vector3<S>, R> {}
 
 impl<S: VectorSpace, R, E: BaseFloat> approx::AbsDiffEq for Decomposed<S, R>
 where

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -70,7 +70,6 @@ pub struct Decomposed<V: VectorSpace, R> {
 impl<P: EuclideanSpace, R: Rotation<Space = P>> One for Decomposed<P::Diff, R>
 where
     P::Scalar: BaseFloat,
-    P::Diff: VectorSpace,
 {
     fn one() -> Self {
         Decomposed {
@@ -105,7 +104,6 @@ where
 impl<P: EuclideanSpace, R: Rotation<Space = P>> Transform<P> for Decomposed<P::Diff, R>
 where
     P::Scalar: BaseFloat,
-    // Needed to be able to multiply by a scalar
     P::Diff: VectorSpace,
 {
     #[inline]

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -93,11 +93,7 @@ where
     /// a (currently nonexistent) function that tries to convert
     /// a matrix into a `Decomposed`.
     fn mul(self, rhs: Decomposed<P::Diff, R>) -> Self::Output {
-        Decomposed {
-            scale: self.scale * rhs.scale,
-            rot: self.rot * rhs.rot,
-            disp: self.disp + self.rot.rotate_vector(rhs.disp * self.scale),
-        }
+        self.concat(&rhs)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use num_traits::{Float, Bounded, NumCast};
+use num_traits::{Bounded, Float, NumCast};
 #[cfg(feature = "rand")]
 use rand::{
     distributions::{Distribution, Standard},
@@ -539,7 +539,10 @@ impl<S: BaseNum> InnerSpace for Vector2<S> {
     }
 
     #[inline]
-    fn angle(self, other: Vector2<S>) -> Rad<S> where S: BaseFloat {
+    fn angle(self, other: Vector2<S>) -> Rad<S>
+    where
+        S: BaseFloat,
+    {
         Rad::atan2(Self::perp_dot(self, other), Self::dot(self, other))
     }
 }
@@ -551,7 +554,10 @@ impl<S: BaseNum> InnerSpace for Vector3<S> {
     }
 
     #[inline]
-    fn angle(self, other: Vector3<S>) -> Rad<S> where S: BaseFloat {
+    fn angle(self, other: Vector3<S>) -> Rad<S>
+    where
+        S: BaseFloat,
+    {
         Rad::atan2(self.cross(other).magnitude(), Self::dot(self, other))
     }
 }

--- a/tests/rotation.rs
+++ b/tests/rotation.rs
@@ -20,11 +20,11 @@ use cgmath::*;
 mod rotation {
     use super::cgmath::*;
 
-    pub fn a2<R: Rotation2<f64>>() -> R {
+    pub fn a2<R: Rotation2<Scalar = f64>>() -> R {
         Rotation2::from_angle(Deg(30.0))
     }
 
-    pub fn a3<R: Rotation3<f64>>() -> R {
+    pub fn a3<R: Rotation3<Scalar = f64>>() -> R {
         let axis = Vector3::new(1.0, 1.0, 0.0).normalize();
         Rotation3::from_axis_angle(axis, Deg(30.0))
     }

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -22,6 +22,43 @@ extern crate serde_json;
 use cgmath::*;
 
 #[test]
+fn test_mul() {
+    let t1 = Decomposed {
+        scale: 2.0f64,
+        rot: Quaternion::new(0.5f64.sqrt(), 0.5f64.sqrt(), 0.0, 0.0),
+        disp: Vector3::new(1.0f64, 2.0, 3.0),
+    };
+    let t2 = Decomposed {
+        scale: 3.0f64,
+        rot: Quaternion::new(0.5f64.sqrt(), 0.0, 0.5f64.sqrt(), 0.0),
+        disp: Vector3::new(-2.0, 1.0, 0.0),
+    };
+
+    let actual = t1 * t2;
+
+    let expected = Decomposed {
+        scale: 6.0f64,
+        rot: Quaternion::new(0.5, 0.5, 0.5, 0.5),
+        disp: Vector3::new(-3.0, 2.0, 5.0),
+    };
+
+    assert_ulps_eq!(actual, expected);
+}
+
+#[test]
+fn test_mul_one() {
+    let t = Decomposed {
+        scale: 2.0f64,
+        rot: Quaternion::new(0.5f64.sqrt(), 0.5f64.sqrt(), 0.0, 0.0),
+        disp: Vector3::new(1.0f64, 2.0, 3.0),
+    };
+    let one = Decomposed::one();
+
+    assert_ulps_eq!(t * one, t);
+    assert_ulps_eq!(one * t, t);
+}
+
+#[test]
 fn test_invert() {
     let v = Vector3::new(1.0f64, 2.0, 3.0);
     let t = Decomposed {


### PR DESCRIPTION
This fixes the `multiple one found` issue (one function mentioned in #354) with attempting to use `Matrix4::one()` or some other matrix's `one()` function when importing the prelude, which includes both `Transform` and `One`. The changes:
- `Transform::one()` is gone
- `Transform` is now a subtrait of `One`
- `Decomposed` implements `One`.
- `EuclideanRotation` is a new trait specifically for implementers of `Rotation<P>` for exactly one `P`. This allows `Decomposed` to implement `One` without running into unconstrained type parameter issues. All current implementers of `Rotation` in the `cgmath` crate implement `EuclideanRotation`.
- `Decomposed` implements `Mul` so it can implement `One`.

I know there was an attempt to do it in #386, but it was abandoned and closed.

There seems to be a few extra changes from running `cargo fmt`.