### PR TITLE
Optional JSON schema generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ num-traits = "0.2"
 rand = { version = "0.7", features = ["small_rng"], optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 simd = { version = "0.2", optional = true }  # works only in rust toolchain up to 1.32
+schemars = { version = "0.7", optional = true }
 
 [dev-dependencies]
 # glium = "0.23"  # causes problems with nightly-2019-01-01 needed for testing "simd"

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -38,6 +38,7 @@ use num::BaseFloat;
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Rad<S>(pub S);
 
 /// An angle, in degrees.
@@ -46,6 +47,7 @@ pub struct Rad<S>(pub S);
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Deg<S>(pub S);
 
 impl<S> From<Rad<S>> for Deg<S>

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -81,6 +81,7 @@ use quaternion::Quaternion;
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Euler<A> {
     /// The angle to apply around the _x_ axis. Also known at the _pitch_.
     pub x: A,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,10 @@ extern crate serde;
 #[cfg(feature = "simd")]
 extern crate simd;
 
+#[cfg(feature = "schemars")]
+#[macro_use]
+extern crate schemars;
+
 // Re-exports
 
 pub use approx::*;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -45,6 +45,7 @@ use mint;
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Matrix2<S> {
     /// The first column of the matrix.
     pub x: Vector2<S>,
@@ -58,6 +59,7 @@ pub struct Matrix2<S> {
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Matrix3<S> {
     /// The first column of the matrix.
     pub x: Vector3<S>,
@@ -73,6 +75,7 @@ pub struct Matrix3<S> {
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Matrix4<S> {
     /// The first column of the matrix.
     pub x: Vector4<S>,

--- a/src/point.rs
+++ b/src/point.rs
@@ -37,6 +37,7 @@ use mint;
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Point1<S> {
     pub x: S,
 }
@@ -47,6 +48,7 @@ pub struct Point1<S> {
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Point2<S> {
     pub x: S,
     pub y: S,
@@ -58,6 +60,7 @@ pub struct Point2<S> {
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Point3<S> {
     pub x: S,
     pub y: S,

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -80,6 +80,7 @@ pub fn ortho<S: BaseFloat>(left: S, right: S, bottom: S, top: S, near: S, far: S
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct PerspectiveFov<S> {
     pub fovy: Rad<S>,
     pub aspect: S,
@@ -176,6 +177,7 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
 /// A perspective projection with arbitrary left/right/bottom/top distances
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Perspective<S> {
     pub left: S,
     pub right: S,
@@ -241,6 +243,7 @@ impl<S: BaseFloat> From<Perspective<S>> for Matrix4<S> {
 /// An orthographic projection with arbitrary left/right/bottom/top distances
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Ortho<S> {
     pub left: S,
     pub right: S,

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -45,6 +45,7 @@ use mint;
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Quaternion<S> {
     /// The scalar part of the quaternion.
     pub s: S,

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -164,6 +164,7 @@ pub trait Rotation3:
 /// ```
 #[derive(PartialEq, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Basis2<S> {
     mat: Matrix2<S>,
 }
@@ -310,6 +311,7 @@ impl<S: fmt::Debug> fmt::Debug for Basis2<S> {
 /// been restricted to a subset of those implemented on `Matrix3`.
 #[derive(PartialEq, Copy, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Basis3<S> {
     mat: Matrix3<S>,
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -39,6 +39,7 @@ use mint;
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Vector1<S> {
     /// The x component of the vector.
     pub x: S,
@@ -50,6 +51,7 @@ pub struct Vector1<S> {
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Vector2<S> {
     /// The x component of the vector.
     pub x: S,
@@ -63,6 +65,7 @@ pub struct Vector2<S> {
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Vector3<S> {
     /// The x component of the vector.
     pub x: S,
@@ -78,6 +81,7 @@ pub struct Vector3<S> {
 #[repr(C)]
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
 pub struct Vector4<S> {
     /// The x component of the vector.
     pub x: S,


### PR DESCRIPTION
Allow users to optionally derive JSON schemas using structs from this crate if they include `schemars`. This will allow consumers of this library to generate JSON schemas from structs that include structs created in this crate.