### PR TITLE
Fix a type argument in benchmarks

### DIFF
--- a/benches/construction.rs
+++ b/benches/construction.rs
@@ -29,7 +29,7 @@ use cgmath::*;
 #[macro_use]
 mod macros;
 
-fn bench_from_axis_angle<T: Rotation3<f32>>(bh: &mut Bencher) {
+fn bench_from_axis_angle<T: Rotation3<Scalar = f32>>(bh: &mut Bencher) {
     const LEN: usize = 1 << 13;
 
     let mut rng = SmallRng::from_entropy();


### PR DESCRIPTION
`Rotation3`’s type argument is an associated type now. Therefore this line https://github.com/rustgd/cgmath/blob/84da664455df0ec6d7583131e985ffd3a184a2f4/benches/construction.rs#L32 will cause following error when running `cargo bench`.

```
error[E0107]: wrong number of type arguments: expected 0, found 1
  --> benches/construction.rs:32:39
   |
32 | fn bench_from_axis_angle<T: Rotation3<f32>>(bh: &mut Bencher) {
   |                                       ^^^ unexpected type argument

error: aborting due to previous error
```

This PR is intended to fix this.

- - - - -

My environments:

* Rust v1.48.0-nightly
* macOS