### PR TITLE
Simplify "fold_array" macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -139,30 +139,8 @@ macro_rules! impl_assignment_operator {
 }
 
 macro_rules! fold_array {
-    (&$method:ident, { $x:expr }) => {
-        *$x
-    };
-    (&$method:ident, { $x:expr, $y:expr }) => {
-        $x.$method(&$y)
-    };
-    (&$method:ident, { $x:expr, $y:expr, $z:expr }) => {
-        $x.$method(&$y).$method(&$z)
-    };
-    (&$method:ident, { $x:expr, $y:expr, $z:expr, $w:expr }) => {
-        $x.$method(&$y).$method(&$z).$method(&$w)
-    };
-    ($method:ident, { $x:expr }) => {
-        $x
-    };
-    ($method:ident, { $x:expr, $y:expr }) => {
-        $x.$method($y)
-    };
-    ($method:ident, { $x:expr, $y:expr, $z:expr }) => {
-        $x.$method($y).$method($z)
-    };
-    ($method:ident, { $x:expr, $y:expr, $z:expr, $w:expr }) => {
-        $x.$method($y).$method($z).$method($w)
-    };
+    ($method:ident, $x:expr) => ($x);
+    ($method:ident, $x:expr, $($y:expr),+) => ($x.$method(fold_array!($method, $($y),+)))
 }
 
 /// Generate array conversion implementations for a compound array type

--- a/src/point.rs
+++ b/src/point.rs
@@ -127,12 +127,12 @@ macro_rules! impl_point {
 
             #[inline]
             fn sum(self) -> S where S: Add<Output = S> {
-                fold_array!(add, { $(self.$field),+ })
+                fold_array!(add, $(self.$field),+ )
             }
 
             #[inline]
             fn product(self) -> S where S: Mul<Output = S> {
-                fold_array!(mul, { $(self.$field),+ })
+                fold_array!(mul, $(self.$field),+ )
             }
 
             fn is_finite(&self) -> bool where S: Float {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -163,12 +163,12 @@ macro_rules! impl_vector {
 
             #[inline]
             fn sum(self) -> S where S: Add<Output = S> {
-                fold_array!(add, { $(self.$field),+ })
+                fold_array!(add, $(self.$field),+ )
             }
 
             #[inline]
             fn product(self) -> S where S: Mul<Output = S> {
-                fold_array!(mul, { $(self.$field),+ })
+                fold_array!(mul, $(self.$field),+ )
             }
 
             fn is_finite(&self) -> bool where S: Float {


### PR DESCRIPTION
- Macro now applies to arbitrary dimensions
- Removes the reference format of the macro `(&$method:ident, { $x:expr })`. Tests passed fine, I couldn't find anywhere it was needed.

Macro expand to an inverted composition:

**Before**
```rust
#[inline]
fn sum(self) -> S
where
    S: Add<Output = S>,
{
    self.x.add(self.y).add(self.z)
}
```

**Now**
```rust
#[inline]
fn sum(self) -> S
where
    S: Add<Output = S>,
{
    self.x.add(self.y.add(self.z))
}
```