### PR TITLE
Implement From instead of Into for array/tuple/mint conversions

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -146,10 +146,10 @@ macro_rules! fold_array {
 /// Generate array conversion implementations for a compound array type
 macro_rules! impl_fixed_array_conversions {
     ($ArrayN:ident <$S:ident> { $($field:ident : $index:expr),+ }, $n:expr) => {
-        impl<$S> Into<[$S; $n]> for $ArrayN<$S> {
+        impl<$S> From<$ArrayN<$S>> for [$S; $n] {
             #[inline]
-            fn into(self) -> [$S; $n] {
-                match self { $ArrayN { $($field),+ } => [$($field),+] }
+            fn from(v: $ArrayN<$S>) -> Self {
+                match v { $ArrayN { $($field),+ } => [$($field),+] }
             }
         }
 
@@ -194,10 +194,10 @@ macro_rules! impl_fixed_array_conversions {
 /// Generate homogeneous tuple conversion implementations for a compound array type
 macro_rules! impl_tuple_conversions {
     ($ArrayN:ident <$S:ident> { $($field:ident),+ }, $Tuple:ty) => {
-        impl<$S> Into<$Tuple> for $ArrayN<$S> {
+        impl<$S> From<$ArrayN<$S>> for $Tuple {
             #[inline]
-            fn into(self) -> $Tuple {
-                match self { $ArrayN { $($field),+ } => ($($field),+,) }
+            fn from(v: $ArrayN<$S>) -> Self {
+                match v { $ArrayN { $($field),+ } => ($($field),+,) }
             }
         }
 
@@ -360,10 +360,10 @@ macro_rules! impl_operator_simd {
 #[cfg(feature = "mint")]
 macro_rules! impl_mint_conversions {
     ($ArrayN:ident { $($field:ident),+ }, $Mint:ident) => {
-        impl<S: Clone> Into<mint::$Mint<S>> for $ArrayN<S> {
+        impl<S: Clone> From<$ArrayN<S>> for mint::$Mint<S> {
             #[inline]
-            fn into(self) -> mint::$Mint<S> {
-                mint::$Mint::from([$(self.$field),+])
+            fn from(v: $ArrayN<S>) -> Self {
+                mint::$Mint::from([$(v.$field),+])
             }
         }
 


### PR DESCRIPTION
Fixes missing impls of `impl From<ArrayN> for ForeignType` which is currently provided as `impl Into<ForeignType> for ArrayN`

From the [`std::convert::Into` documentation](https://doc.rust-lang.org/stable/std/convert/trait.Into.html):

> One should avoid implementing Into and implement From instead. Implementing From automatically provides one with an implementation of Into thanks to the blanket implementation in the standard library.

While it isn't very significant, as you can write `cgmath_vector.into()` in most places, it makes code cleaner where type inference is not possible (e.g. `format!` macros):

```rust
// With `Into`: 
<Vector2<f32> as Into<[f32; 2]>>::into(a_vector)

// ... versus with `From`:
<[f32; 2]>::from(a_vector)
```

  (Example adapted from this [real code snippet](https://github.com/agausmann/FlipFlop/blob/0087e9b579235dd4ff1a62643584c7029df58c5d/src/main.rs#L397-L401) that I had to write)