### PR TITLE
update approx to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ unstable = []
 swizzle = []
 
 [dependencies]
-approx = "0.4"
+approx = "0.5"
 mint = { version = "0.5", optional = true }
 num-traits = "0.2"
 # small_rng used only for benchmarks


### PR DESCRIPTION
Hi.
I am in the process of packaging ``cgmath`` in fedora and it would ease the process to update ``approx`` to 0.5.
Thanks for your time.