### PR TITLE
Remove NumCast from BaseNum and relax float bounds

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -30,7 +30,7 @@ use rand::{
 use structure::*;
 
 use approx;
-use num::BaseFloat;
+use num::{BaseFloat, BaseNum};
 
 /// An angle, in radians.
 ///
@@ -138,38 +138,38 @@ macro_rules! impl_angle {
             }
         }
 
-        impl_operator!(<S: BaseFloat> Add<$Angle<S> > for $Angle<S> {
+        impl_operator!(<S: BaseNum> Add<$Angle<S> > for $Angle<S> {
             fn add(lhs, rhs) -> $Angle<S> { $Angle(lhs.0 + rhs.0) }
         });
-        impl_operator!(<S: BaseFloat> Sub<$Angle<S> > for $Angle<S> {
+        impl_operator!(<S: BaseNum> Sub<$Angle<S> > for $Angle<S> {
             fn sub(lhs, rhs) -> $Angle<S> { $Angle(lhs.0 - rhs.0) }
         });
-        impl_operator!(<S: BaseFloat> Div<$Angle<S> > for $Angle<S> {
+        impl_operator!(<S: BaseNum> Div<$Angle<S> > for $Angle<S> {
             fn div(lhs, rhs) -> S { lhs.0 / rhs.0 }
         });
-        impl_operator!(<S: BaseFloat> Rem<$Angle<S> > for $Angle<S> {
+        impl_operator!(<S: BaseNum> Rem<$Angle<S> > for $Angle<S> {
             fn rem(lhs, rhs) -> $Angle<S> { $Angle(lhs.0 % rhs.0) }
         });
-        impl_assignment_operator!(<S: BaseFloat> AddAssign<$Angle<S> > for $Angle<S> {
+        impl_assignment_operator!(<S: BaseNum> AddAssign<$Angle<S> > for $Angle<S> {
             fn add_assign(&mut self, other) { self.0 += other.0; }
         });
-        impl_assignment_operator!(<S: BaseFloat> SubAssign<$Angle<S> > for $Angle<S> {
+        impl_assignment_operator!(<S: BaseNum> SubAssign<$Angle<S> > for $Angle<S> {
             fn sub_assign(&mut self, other) { self.0 -= other.0; }
         });
-        impl_assignment_operator!(<S: BaseFloat> RemAssign<$Angle<S> > for $Angle<S> {
+        impl_assignment_operator!(<S: BaseNum> RemAssign<$Angle<S> > for $Angle<S> {
             fn rem_assign(&mut self, other) { self.0 %= other.0; }
         });
 
-        impl_operator!(<S: BaseFloat> Mul<S> for $Angle<S> {
+        impl_operator!(<S: BaseNum> Mul<S> for $Angle<S> {
             fn mul(lhs, scalar) -> $Angle<S> { $Angle(lhs.0 * scalar) }
         });
-        impl_operator!(<S: BaseFloat> Div<S> for $Angle<S> {
+        impl_operator!(<S: BaseNum> Div<S> for $Angle<S> {
             fn div(lhs, scalar) -> $Angle<S> { $Angle(lhs.0 / scalar) }
         });
-        impl_assignment_operator!(<S: BaseFloat> MulAssign<S> for $Angle<S> {
+        impl_assignment_operator!(<S: BaseNum> MulAssign<S> for $Angle<S> {
             fn mul_assign(&mut self, scalar) { self.0 *= scalar; }
         });
-        impl_assignment_operator!(<S: BaseFloat> DivAssign<S> for $Angle<S> {
+        impl_assignment_operator!(<S: BaseNum> DivAssign<S> for $Angle<S> {
             fn div_assign(&mut self, scalar) { self.0 /= scalar; }
         });
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -30,7 +30,7 @@ use structure::*;
 use angle::Rad;
 use approx;
 use euler::Euler;
-use num::BaseFloat;
+use num::{BaseFloat, BaseNum};
 use point::{Point2, Point3};
 use quaternion::Quaternion;
 use transform::{Transform, Transform2, Transform3};
@@ -1569,7 +1569,7 @@ mint_conversions!(Matrix3 { x, y, z }, ColumnMatrix3);
 #[cfg(feature = "mint")]
 mint_conversions!(Matrix4 { x, y, z, w }, ColumnMatrix4);
 
-impl<S: BaseFloat> From<Matrix2<S>> for Matrix3<S> {
+impl<S: BaseNum> From<Matrix2<S>> for Matrix3<S> {
     /// Clone the elements of a 2-dimensional matrix into the top-left corner
     /// of a 3-dimensional identity matrix.
     fn from(m: Matrix2<S>) -> Matrix3<S> {
@@ -1582,7 +1582,7 @@ impl<S: BaseFloat> From<Matrix2<S>> for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> From<Matrix2<S>> for Matrix4<S> {
+impl<S: BaseNum> From<Matrix2<S>> for Matrix4<S> {
     /// Clone the elements of a 2-dimensional matrix into the top-left corner
     /// of a 4-dimensional identity matrix.
     fn from(m: Matrix2<S>) -> Matrix4<S> {
@@ -1596,7 +1596,7 @@ impl<S: BaseFloat> From<Matrix2<S>> for Matrix4<S> {
     }
 }
 
-impl<S: BaseFloat> From<Matrix3<S>> for Matrix4<S> {
+impl<S: BaseNum> From<Matrix3<S>> for Matrix4<S> {
     /// Clone the elements of a 3-dimensional matrix into the top-left corner
     /// of a 4-dimensional identity matrix.
     fn from(m: Matrix3<S>) -> Matrix4<S> {
@@ -1678,7 +1678,7 @@ impl<S: fmt::Debug> fmt::Debug for Matrix4<S> {
 impl<S> Distribution<Matrix2<S>> for Standard
 where
     Standard: Distribution<Vector2<S>>,
-    S: BaseFloat,
+    S: BaseNum,
 {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Matrix2<S> {
@@ -1693,7 +1693,7 @@ where
 impl<S> Distribution<Matrix3<S>> for Standard
 where
     Standard: Distribution<Vector3<S>>,
-    S: BaseFloat,
+    S: BaseNum,
 {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Matrix3<S> {
@@ -1709,7 +1709,7 @@ where
 impl<S> Distribution<Matrix4<S>> for Standard
 where
     Standard: Distribution<Vector4<S>>,
-    S: BaseFloat,
+    S: BaseNum,
 {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Matrix4<S> {

--- a/src/num.rs
+++ b/src/num.rs
@@ -18,7 +18,7 @@ use approx;
 use std::fmt;
 use std::ops::*;
 
-use num_traits::{Float, Num, NumCast};
+use num_traits::{Float, Num};
 
 /// Base numeric types with partial ordering
 pub trait BaseNum:
@@ -26,7 +26,6 @@ pub trait BaseNum:
     + Clone
     + fmt::Debug
     + Num
-    + NumCast
     + PartialOrd
     + AddAssign
     + SubAssign
@@ -41,7 +40,6 @@ impl<T> BaseNum for T where
         + Clone
         + fmt::Debug
         + Num
-        + NumCast
         + PartialOrd
         + AddAssign
         + SubAssign

--- a/src/point.rs
+++ b/src/point.rs
@@ -154,7 +154,7 @@ macro_rules! impl_point {
             }
         }
 
-        impl<S: BaseFloat> MetricSpace for $PointN<S> {
+        impl<S: BaseNum> MetricSpace for $PointN<S> {
             type Metric = S;
 
             #[inline]

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -29,7 +29,7 @@ use angle::Rad;
 use approx;
 use euler::Euler;
 use matrix::{Matrix3, Matrix4};
-use num::BaseFloat;
+use num::{BaseFloat, BaseNum};
 use point::Point3;
 use quaternion;
 use rotation::{Basis3, Rotation, Rotation3};
@@ -410,7 +410,7 @@ impl<S: BaseFloat> approx::UlpsEq for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> From<Quaternion<S>> for Matrix3<S> {
+impl<S: BaseNum> From<Quaternion<S>> for Matrix3<S> {
     /// Convert the quaternion to a 3 x 3 rotation matrix.
     fn from(quat: Quaternion<S>) -> Matrix3<S> {
         let x2 = quat.v.x + quat.v.x;
@@ -438,7 +438,7 @@ impl<S: BaseFloat> From<Quaternion<S>> for Matrix3<S> {
     }
 }
 
-impl<S: BaseFloat> From<Quaternion<S>> for Matrix4<S> {
+impl<S: BaseNum> From<Quaternion<S>> for Matrix4<S> {
     /// Convert the quaternion to a 4 x 4 rotation matrix.
     fn from(quat: Quaternion<S>) -> Matrix4<S> {
         let x2 = quat.v.x + quat.v.x;
@@ -534,7 +534,7 @@ impl<S: BaseFloat> Rotation3 for Quaternion<S> {
     }
 }
 
-impl<S: BaseFloat> From<Quaternion<S>> for [S; 4] {
+impl<S: BaseNum> From<Quaternion<S>> for [S; 4] {
     #[inline]
     fn from(v: Quaternion<S>) -> Self {
         let (xi, yj, zk, w) = v.into();
@@ -542,42 +542,42 @@ impl<S: BaseFloat> From<Quaternion<S>> for [S; 4] {
     }
 }
 
-impl<S: BaseFloat> AsRef<[S; 4]> for Quaternion<S> {
+impl<S: BaseNum> AsRef<[S; 4]> for Quaternion<S> {
     #[inline]
     fn as_ref(&self) -> &[S; 4] {
         unsafe { &*(self as *const quaternion::Quaternion<S> as *const [S; 4]) }
     }
 }
 
-impl<S: BaseFloat> AsMut<[S; 4]> for Quaternion<S> {
+impl<S: BaseNum> AsMut<[S; 4]> for Quaternion<S> {
     #[inline]
     fn as_mut(&mut self) -> &mut [S; 4] {
         unsafe { &mut *(self as *mut quaternion::Quaternion<S> as *mut [S; 4]) }
     }
 }
 
-impl<S: BaseFloat> From<[S; 4]> for Quaternion<S> {
+impl<S: BaseNum> From<[S; 4]> for Quaternion<S> {
     #[inline]
     fn from(v: [S; 4]) -> Quaternion<S> {
         Quaternion::new(v[3], v[0], v[1], v[2])
     }
 }
 
-impl<'a, S: BaseFloat> From<&'a [S; 4]> for &'a Quaternion<S> {
+impl<'a, S: BaseNum> From<&'a [S; 4]> for &'a Quaternion<S> {
     #[inline]
     fn from(v: &'a [S; 4]) -> &'a Quaternion<S> {
         unsafe { &*(v as *const [S; 4] as *const quaternion::Quaternion<S>) }
     }
 }
 
-impl<'a, S: BaseFloat> From<&'a mut [S; 4]> for &'a mut Quaternion<S> {
+impl<'a, S: BaseNum> From<&'a mut [S; 4]> for &'a mut Quaternion<S> {
     #[inline]
     fn from(v: &'a mut [S; 4]) -> &'a mut Quaternion<S> {
         unsafe { &mut *(v as *mut [S; 4] as *mut quaternion::Quaternion<S>) }
     }
 }
 
-impl<S: BaseFloat> From<Quaternion<S>> for (S, S, S, S) {
+impl<S: BaseNum> From<Quaternion<S>> for (S, S, S, S) {
     #[inline]
     fn from(v: Quaternion<S>) -> Self {
         let Quaternion {
@@ -588,21 +588,21 @@ impl<S: BaseFloat> From<Quaternion<S>> for (S, S, S, S) {
     }
 }
 
-impl<S: BaseFloat> AsRef<(S, S, S, S)> for Quaternion<S> {
+impl<S: BaseNum> AsRef<(S, S, S, S)> for Quaternion<S> {
     #[inline]
     fn as_ref(&self) -> &(S, S, S, S) {
         unsafe { &*(self as *const quaternion::Quaternion<S> as *const (S, S, S, S)) }
     }
 }
 
-impl<S: BaseFloat> AsMut<(S, S, S, S)> for Quaternion<S> {
+impl<S: BaseNum> AsMut<(S, S, S, S)> for Quaternion<S> {
     #[inline]
     fn as_mut(&mut self) -> &mut (S, S, S, S) {
         unsafe { &mut *(self as *mut quaternion::Quaternion<S> as *mut (S, S, S, S)) }
     }
 }
 
-impl<S: BaseFloat> From<(S, S, S, S)> for Quaternion<S> {
+impl<S: BaseNum> From<(S, S, S, S)> for Quaternion<S> {
     #[inline]
     fn from(v: (S, S, S, S)) -> Quaternion<S> {
         let (xi, yj, zk, w) = v;
@@ -610,14 +610,14 @@ impl<S: BaseFloat> From<(S, S, S, S)> for Quaternion<S> {
     }
 }
 
-impl<'a, S: BaseFloat> From<&'a (S, S, S, S)> for &'a Quaternion<S> {
+impl<'a, S: BaseNum> From<&'a (S, S, S, S)> for &'a Quaternion<S> {
     #[inline]
     fn from(v: &'a (S, S, S, S)) -> &'a Quaternion<S> {
         unsafe { &*(v as *const (S, S, S, S) as *const quaternion::Quaternion<S>) }
     }
 }
 
-impl<'a, S: BaseFloat> From<&'a mut (S, S, S, S)> for &'a mut Quaternion<S> {
+impl<'a, S: BaseNum> From<&'a mut (S, S, S, S)> for &'a mut Quaternion<S> {
     #[inline]
     fn from(v: &'a mut (S, S, S, S)) -> &'a mut Quaternion<S> {
         unsafe { &mut *(v as *mut (S, S, S, S) as *mut quaternion::Quaternion<S>) }
@@ -626,7 +626,7 @@ impl<'a, S: BaseFloat> From<&'a mut (S, S, S, S)> for &'a mut Quaternion<S> {
 
 macro_rules! index_operators {
     ($S:ident, $Output:ty, $I:ty) => {
-        impl<$S: BaseFloat> Index<$I> for Quaternion<$S> {
+        impl<$S: BaseNum> Index<$I> for Quaternion<$S> {
             type Output = $Output;
 
             #[inline]
@@ -636,7 +636,7 @@ macro_rules! index_operators {
             }
         }
 
-        impl<$S: BaseFloat> IndexMut<$I> for Quaternion<$S> {
+        impl<$S: BaseNum> IndexMut<$I> for Quaternion<$S> {
             #[inline]
             fn index_mut<'a>(&'a mut self, i: $I) -> &'a mut $Output {
                 let v: &mut [$S; 4] = self.as_mut();
@@ -657,7 +657,7 @@ impl<S> Distribution<Quaternion<S>> for Standard
 where
     Standard: Distribution<S>,
     Standard: Distribution<Vector3<S>>,
-    S: BaseFloat,
+    S: BaseNum,
 {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Quaternion<S> {

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -23,7 +23,7 @@ use angle::Rad;
 use approx;
 use euler::Euler;
 use matrix::{Matrix2, Matrix3};
-use num::BaseFloat;
+use num::{BaseFloat, BaseNum};
 use point::{Point2, Point3};
 use quaternion::Quaternion;
 use vector::{Vector2, Vector3};
@@ -36,7 +36,7 @@ where
     Self: approx::AbsDiffEq<Epsilon = <<Self as Rotation>::Space as EuclideanSpace>::Scalar>,
     Self: approx::RelativeEq<Epsilon = <<Self as Rotation>::Space as EuclideanSpace>::Scalar>,
     Self: approx::UlpsEq<Epsilon = <<Self as Rotation>::Space as EuclideanSpace>::Scalar>,
-    <Self::Space as EuclideanSpace>::Scalar: BaseFloat,
+    <Self::Space as EuclideanSpace>::Scalar: BaseNum,
     Self: iter::Product<Self>,
 {
     type Space: EuclideanSpace;

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -25,7 +25,7 @@ use approx;
 use angle::Rad;
 use num::{BaseFloat, BaseNum};
 
-pub use num_traits::{Bounded, NumCast, One, Zero};
+pub use num_traits::{Bounded, Num, NumCast, One, Zero};
 
 /// An array containing elements of type `Element`
 pub trait Array
@@ -441,7 +441,7 @@ where
 /// see `SquareMatrix`.
 pub trait Matrix: VectorSpace
 where
-    Self::Scalar: Float,
+    Self::Scalar: Num,
 
     // FIXME: Ugly type signatures - blocked by rust-lang/rust#24092
     Self: Index<usize, Output = <Self as Matrix>::Column>,
@@ -493,7 +493,7 @@ where
 /// A column-major major matrix where the rows and column vectors are of the same dimensions.
 pub trait SquareMatrix
 where
-    Self::Scalar: Float,
+    Self::Scalar: Num,
 
     Self: One,
     Self: iter::Product<Self>,

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -25,7 +25,7 @@ use approx;
 use angle::Rad;
 use num::{BaseFloat, BaseNum};
 
-pub use num_traits::{Bounded, One, Zero};
+pub use num_traits::{Bounded, NumCast, One, Zero};
 
 /// An array containing elements of type `Element`
 pub trait Array
@@ -388,7 +388,7 @@ where
     /// ```
     #[inline]
     fn midpoint(self, other: Self) -> Self {
-        self + (other - self) / cast(2).unwrap()
+        self + (other - self) / (Self::Scalar::one() + Self::Scalar::one())
     }
 
     /// Returns the average position of all points in the slice.
@@ -406,7 +406,7 @@ where
     /// let centroid = Point2::centroid(&triangle);
     /// ```
     #[inline]
-    fn centroid(points: &[Self]) -> Self {
+    fn centroid(points: &[Self]) -> Self where Self::Scalar: NumCast {
         let total_displacement = points
             .iter()
             .fold(Self::Diff::zero(), |acc, p| acc + p.to_vec());

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -254,7 +254,7 @@ macro_rules! impl_vector {
         #[cfg(feature = "rand")]
         impl<S> Distribution<$VectorN<S>> for Standard
             where Standard: Distribution<S>,
-                S: BaseFloat {
+                S: BaseNum {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $VectorN<S> {
                 $VectorN { $($field: rng.gen()),+ }
@@ -520,7 +520,7 @@ impl<S: BaseNum> Vector4<S> {
 #[inline]
 pub fn dot<V: InnerSpace>(a: V, b: V) -> V::Scalar
 where
-    V::Scalar: BaseFloat,
+    V::Scalar: BaseNum,
 {
     V::dot(a, b)
 }


### PR DESCRIPTION
The first commit removes the NumCast from the BaseNum trait. This is enough to allow using non-machine scalars (e.g. fixed precision numbers) for vector/point operations:
```
#![feature(array_map)]

use cgmath::InnerSpace;
use fixed::types::I16F16 as Ftype;

macro_rules! show {
    ($e:expr) => {
        println!("{}: {:?}", stringify!($e), $e);
    };
}

fn main() {
    let p1: cgmath::Point2<Ftype> = [0, 1].map(Ftype::from_num).into();
    show!(p1);
    let p2: cgmath::Point2<Ftype> = [1, 0].map(Ftype::from_num).into();
    show!(p2);
    show!(p2 - p1);
    let v: cgmath::Vector2<Ftype> = [1, 1].map(Ftype::from_num).into();
    show!(v);
    show!(p1 + v);
    show!(v.magnitude2());
    show!(v.dot(v));
}
```
- `cast` is already parameterized by `T: NumCast`
- The `midpoint` method used cast to create a generic value of '2', but this can be replaced by `One::() + One::()`
- The only other BaseNum method using `cast` is `centroid`, to which is added an explicit `where Self::Scalar: NumCast` constraint

The second commit replaces uses of BaseFloat and Float with BaseNum and Num where possible. This might help with making finer grained trait bounds down the road (https://github.com/rustgd/cgmath/issues/496).