### PR TITLE
Implement IntoMint trait for Vectors, Points, Matrices, and Quaternions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ swizzle = []
 
 [dependencies]
 approx = "0.5"
-mint = { version = "0.5", optional = true }
+mint = { version = "0.5.8", optional = true }
 num-traits = "0.2"
 # small_rng used only for benchmarks
 rand = { version = "0.8", features = ["small_rng"], optional = true }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -373,6 +373,10 @@ macro_rules! impl_mint_conversions {
                 $ArrayN { $( $field: v.$field, )+ }
             }
         }
+        
+        impl<S: Clone> mint::IntoMint for $ArrayN<S> {
+            type MintType = mint::$Mint<S>;
+        }
     }
 }
 

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1558,7 +1558,10 @@ macro_rules! mint_conversions {
                 $MatrixN { $($field: m.$field.into()),+ }
             }
         }
-
+        
+        impl<S: Clone> mint::IntoMint for $MatrixN<S> {
+            type MintType = mint::$MintN<S>;
+        }
     }
 }
 

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -685,6 +685,11 @@ impl<S: Clone> From<Quaternion<S>> for mint::Quaternion<S> {
     }
 }
 
+#[cfg(feature = "mint")]
+impl <S: Clone> mint::IntoMint for Quaternion<S> {
+    type MintType = mint::Quaternion<S>;
+}
+
 #[cfg(test)]
 mod tests {
     use quaternion::*;


### PR DESCRIPTION
Mint 0.5.8 added a new trait called [IntoMint](https://docs.rs/mint/0.5.8/mint/trait.IntoMint.html), which lets you specify the mint type that another type is associated with. That way you can convert a type into its mint representation without having to specify the mint type.

I implemented IntoMint for Vectors, Points, Matrices, and Quaternions.

I didn't implement IntoMint for Euler angles, because I couldn't figure out which mint type they should correspond to.