### PR TITLE
Add support for cast using bytemuck crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rand = { version = "0.8", features = ["small_rng"], optional = true }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 # works only in rust toolchain up to 1.32, disabled indefinitely
 #simd = { version = "0.2", optional = true }
+bytemuck = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -224,3 +224,6 @@ impl<S: Clone, A: Angle + Into<S>> From<Euler<A>> for MintEuler<S> {
         MintEuler::from([v.x.into(), v.y.into(), v.z.into()])
     }
 }
+
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Euler);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@
 #[macro_use]
 extern crate approx;
 
+#[cfg(feature = "bytemuck")]
+extern crate bytemuck;
+
 #[cfg(feature = "mint")]
 pub extern crate mint;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -380,4 +380,13 @@ macro_rules! impl_mint_conversions {
     }
 }
 
+/// Generate implementation required to cast using `bytemuck`
+#[cfg(feature = "bytemuck")]
+macro_rules! impl_bytemuck_cast {
+    ($ArrayN:ident) => {
+        unsafe impl<S: bytemuck::Pod> bytemuck::Pod for $ArrayN<S> {}
+        unsafe impl<S: bytemuck::Zeroable> bytemuck::Zeroable for $ArrayN<S> {}
+    };
+}
+
 include!(concat!(env!("OUT_DIR"), "/swizzle_operator_macro.rs"));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -373,7 +373,7 @@ macro_rules! impl_mint_conversions {
                 $ArrayN { $( $field: v.$field, )+ }
             }
         }
-        
+
         impl<S: Clone> mint::IntoMint for $ArrayN<S> {
             type MintType = mint::$Mint<S>;
         }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1558,7 +1558,7 @@ macro_rules! mint_conversions {
                 $MatrixN { $($field: m.$field.into()),+ }
             }
         }
-        
+
         impl<S: Clone> mint::IntoMint for $MatrixN<S> {
             type MintType = mint::$MintN<S>;
         }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1572,6 +1572,13 @@ mint_conversions!(Matrix3 { x, y, z }, ColumnMatrix3);
 #[cfg(feature = "mint")]
 mint_conversions!(Matrix4 { x, y, z, w }, ColumnMatrix4);
 
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Matrix2);
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Matrix3);
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Matrix4);
+
 impl<S: BaseNum> From<Matrix2<S>> for Matrix3<S> {
     /// Clone the elements of a 2-dimensional matrix into the top-left corner
     /// of a 3-dimensional identity matrix.

--- a/src/point.rs
+++ b/src/point.rs
@@ -368,6 +368,13 @@ impl_mint_conversions!(Point2 { x, y }, Point2);
 #[cfg(feature = "mint")]
 impl_mint_conversions!(Point3 { x, y, z }, Point3);
 
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Point1);
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Point2);
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Point3);
+
 impl<S: fmt::Debug> fmt::Debug for Point1<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Point1 ")?;

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -690,6 +690,9 @@ impl <S: Clone> mint::IntoMint for Quaternion<S> {
     type MintType = mint::Quaternion<S>;
 }
 
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Quaternion);
+
 #[cfg(test)]
 mod tests {
     use quaternion::*;

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -686,7 +686,7 @@ impl<S: Clone> From<Quaternion<S>> for mint::Quaternion<S> {
 }
 
 #[cfg(feature = "mint")]
-impl <S: Clone> mint::IntoMint for Quaternion<S> {
+impl<S: Clone> mint::IntoMint for Quaternion<S> {
     type MintType = mint::Quaternion<S>;
 }
 

--- a/src/structure.rs
+++ b/src/structure.rs
@@ -406,7 +406,10 @@ where
     /// let centroid = Point2::centroid(&triangle);
     /// ```
     #[inline]
-    fn centroid(points: &[Self]) -> Self where Self::Scalar: NumCast {
+    fn centroid(points: &[Self]) -> Self
+    where
+        Self::Scalar: NumCast,
+    {
         let total_displacement = points
             .iter()
             .fold(Self::Diff::zero(), |acc, p| acc + p.to_vec());

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -597,6 +597,18 @@ impl<S: fmt::Debug> fmt::Debug for Vector4<S> {
     }
 }
 
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Vector1);
+
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Vector2);
+
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Vector3);
+
+#[cfg(feature = "bytemuck")]
+impl_bytemuck_cast!(Vector4);
+
 #[cfg(feature = "mint")]
 impl_mint_conversions!(Vector2 { x, y }, Vector2);
 #[cfg(feature = "mint")]


### PR DESCRIPTION
Added support for [bytemuck](https://docs.rs/bytemuck) crate.

I also applied `cargo fmt`, but I think it is out of scope, so I can remove that changes if you mind.