### PR TITLE
Support infinite far planes

### DIFF
--- a/src/projection.rs
+++ b/src/projection.rs
@@ -140,6 +140,7 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
             persp.near
         );
 
+        let one: S = cast(1).unwrap();
         let two: S = cast(2).unwrap();
         let f = Rad::cot(persp.fovy / two);
 
@@ -155,12 +156,20 @@ impl<S: BaseFloat> From<PerspectiveFov<S>> for Matrix4<S> {
 
         let c2r0 = S::zero();
         let c2r1 = S::zero();
-        let c2r2 = (persp.far + persp.near) / (persp.near - persp.far);
+        let c2r2 = if persp.far.is_finite() {
+            (persp.far + persp.near) / (persp.near - persp.far)
+        } else {
+            -one
+        };
         let c2r3 = -S::one();
 
         let c3r0 = S::zero();
         let c3r1 = S::zero();
-        let c3r2 = (two * persp.far * persp.near) / (persp.near - persp.far);
+        let c3r2 = if persp.far.is_finite() {
+            (two * persp.far * persp.near) / (persp.near - persp.far)
+        } else {
+            -two * persp.near
+        };
         let c3r3 = S::zero();
 
         #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -206,6 +215,7 @@ impl<S: BaseFloat> From<Perspective<S>> for Matrix4<S> {
             persp.far
         );
 
+        let one: S = cast(1i8).unwrap();
         let two: S = cast(2i8).unwrap();
 
         let c0r0 = (two * persp.near) / (persp.right - persp.left);
@@ -220,12 +230,20 @@ impl<S: BaseFloat> From<Perspective<S>> for Matrix4<S> {
 
         let c2r0 = (persp.right + persp.left) / (persp.right - persp.left);
         let c2r1 = (persp.top + persp.bottom) / (persp.top - persp.bottom);
-        let c2r2 = -(persp.far + persp.near) / (persp.far - persp.near);
+        let c2r2 = if persp.far.is_finite() {
+            (persp.far + persp.near) / (persp.near - persp.far)
+        } else {
+            -one
+        };
         let c2r3 = -S::one();
 
         let c3r0 = S::zero();
         let c3r1 = S::zero();
-        let c3r2 = -(two * persp.far * persp.near) / (persp.far - persp.near);
+        let c3r2 = if persp.far.is_finite() {
+            (two * persp.far * persp.near) / (persp.near - persp.far)
+        } else {
+            -two * persp.near
+        };
         let c3r3 = S::zero();
 
         #[cfg_attr(rustfmt, rustfmt_skip)]


### PR DESCRIPTION
Infinite far planes is a standard trick that actually improves the precision of the Z buffer.

See for instance https://thxforthefish.com/posts/reverse_z/