### PR TITLE
Planar projection (perspective/orthographic combination projection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The library provides:
 - rotation matrices: `Basis2`, `Basis3`
 - angle units: `Rad`, `Deg`
 - points: `Point2`, `Point3`
-- perspective projections: `Perspective`, `PerspectiveFov`, `Ortho`
+- perspective projections: `Perspective`, `PerspectiveFov`, `Ortho`, `PlanarFov`
 - spatial transformations: `AffineMatrix3`, `Transform3`
 
 Not all of the functionality has been implemented yet, and the existing code


### PR DESCRIPTION
This adds a new type, `PlanarFOV`, and a new function `planar` to create a projection matrix for which the view space is projected to a plane at zero depth, currently two units high. This allows the focal point to move freely according to the specified vertical field of view, making for a continuous transition from positive FOV to zero or even negative FOV.

I'm unsure of using the name `PlanarFOV` for this, which was derived from how it keeps a plane's transformation fixed as the FOV is adjusted. Additionally, it may be appropriate to add a height parameter to customize the height of the fixed plane instead of fixing it to extend one unit in each direction.

If desired, I can add some test cases to verify the boundary constraints that this projection was derived from.