### PR TITLE
Fix planar projection focal calculation

### DIFF
--- a/src/projection.rs
+++ b/src/projection.rs
@@ -336,7 +336,7 @@ impl<S: BaseFloat> From<PlanarFov<S>> for Matrix4<S> {
         }
 
         let two: S = cast(2).unwrap();
-        let inv_f = Rad::tan(persp.fovy / two);
+        let inv_f = Rad::tan(persp.fovy / two) * two / persp.height;
 
         let focal_point = -inv_f.recip();
 


### PR DESCRIPTION
The planar projection math from #556 had an error in how the focal point was calculated, where it assumed the height was equal to `2.0`. This fixes that by adding height as a parameter to that expression.