### PR TITLE
Fix bisect function to calculate average correctly

### DIFF
--- a/src/structure.rs
+++ b/src/structure.rs
@@ -644,7 +644,7 @@ where
     #[inline]
     fn bisect(self, other: Self) -> Self {
         let half = cast(0.5f64).unwrap();
-        Self::normalize((self - other) * half + self)
+        Self::normalize((self + other) * half)
     }
 
     /// A full rotation.


### PR DESCRIPTION
e.g. `Deg(5.0).bisect(Deg(10.0))` gives you `Deg(2.5)` instead of the expected `Deg(7.5)`